### PR TITLE
Added AM/PM indicator

### DIFF
--- a/Info-Orbs/include/widgets/clockWidget.h
+++ b/Info-Orbs/include/widgets/clockWidget.h
@@ -1,28 +1,29 @@
 #ifndef CLOCKWIDGET_H
 #define CLOCKWIDGET_H
 
-#include <widget.h>
 #include <globalTime.h>
+#include <widget.h>
 
 class ClockWidget : public Widget {
-public:
+   public:
     ClockWidget(ScreenManager& manager);
     ~ClockWidget() override;
     void setup() override;
     void update(bool force = false) override;
     void draw(bool force = false) override;
     void changeMode() override;
-private:
 
+   private:
     void displayDidget(int displayIndex, const String& didget, int font, int fontSize, uint32_t color, bool shadowing);
     void displayDidget(int displayIndex, const String& didget, int font, int fontSize, uint32_t color);
     void displaySeconds(int displayIndex, int seconds, int color);
+    void displayAmPm(uint32_t color);
 
     time_t m_unixEpoch;
     int m_timeZoneOffset;
 
     // Delays for setting how often certain screens/functions are refreshed/checked. These include both the frequency which they need to be checked and a varibale to store the last checked value.
-    long m_secondTimer = 1000; // this time is used to refressh/check the clock every second.
+    long m_secondTimer = 2000;  // this time is used to refressh/check the clock every second.
     long m_secondTimerPrev = 0;
 
     // WiFiUDP m_udp;
@@ -32,19 +33,19 @@ private:
     int m_hourSingle;
     int m_secondSingle;
 
-    int m_lastMinuteSingle { -1 };
-    int m_lastHourSingle { -1 };
-    int m_lastSecondSingle { -1 };
+    int m_lastMinuteSingle{-1};
+    int m_lastHourSingle{-1};
+    int m_lastSecondSingle{-1};
 
     // Didgets
     String m_display1Didget;
-    String m_lastDisplay1Didget{ "-1" };    
+    String m_lastDisplay1Didget{"-1"};
     String m_display2Didget;
-    String m_lastDisplay2Didget{ "-1" };
-    //Display 3 is : 
+    String m_lastDisplay2Didget{"-1"};
+    // Display 3 is :
     String m_display4Didget;
-    String m_lastDisplay4Didget{ "-1" };
+    String m_lastDisplay4Didget{"-1"};
     String m_display5Didget;
-    String m_lastDisplay5Didget{ "-1" };
+    String m_lastDisplay5Didget{"-1"};
 };
-#endif // CLOCKWIDGET_H
+#endif  // CLOCKWIDGET_H

--- a/Info-Orbs/lib/config/config.h.template
+++ b/Info-Orbs/lib/config/config.h.template
@@ -135,6 +135,6 @@
 #define STOCK_TICKERS { "ABNB", "BRCC", "GOOG", "TSLA", "GME" }
 
 #define BG_COLOR 0x20a1         // clock shadow colour(Light brown)
-#define LIGHT_ORANGE 0xfc80  // orange for clock
+#define FOREGROUND_COLOR 0xfc80  // orange for clock
 
 #endif

--- a/Info-Orbs/src/widgets/clockWidget.cpp
+++ b/Info-Orbs/src/widgets/clockWidget.cpp
@@ -17,7 +17,8 @@ void ClockWidget::setup() {
 }
 
 void ClockWidget::draw(bool force) {
-    if ((FORMAT_24_HOUR && m_lastDisplay1Didget != m_display1Didget) || force) {
+    bool showFirstDigit = FORMAT_24_HOUR || (!FORMAT_24_HOUR && m_hourSingle >= 10);
+    if ((showFirstDigit && m_lastDisplay1Didget != m_display1Didget) || force) {
         displayDidget(0, m_display1Didget, 7, 5, FOREGROUND_COLOR);
         m_lastDisplay1Didget = m_display1Didget;
     }


### PR DESCRIPTION
Trello Card: https://trello.com/c/xvt8dQHC/81-add-am-pm-indicator-to-clock-widget

## Changes
This PR adds a simple AM/PM indicator based on the `FORMAT_24_HOUR` setting in `config.h`

## Testing
In `config.h` set `FORMAT_24_HOUR` to false` to see the indicator. Based on your current time, it should say AM or PM.

## Misc
![image](https://github.com/brettdottech/info-orbs/assets/6775551/de0c27e3-339c-4080-8898-5f02ab856340)

