### PR TITLE
Added setting for AM PM. Fixed 12 hour not being respected

### DIFF
--- a/Info-Orbs/lib/config/config.h.template
+++ b/Info-Orbs/lib/config/config.h.template
@@ -127,6 +127,7 @@
 
 #define TIME_ZONE_OFFSET -4
 #define FORMAT_24_HOUR true
+#define SHOW_AM_PM_INDICATOR false
 
 #define WEATHER_LOCAION "Aberdeen,ID"
 #define WEATHER_UNITS_METRIC

--- a/Info-Orbs/lib/globalTime/globalTime.cpp
+++ b/Info-Orbs/lib/globalTime/globalTime.cpp
@@ -1,4 +1,5 @@
 #include "globalTime.h"
+
 #include <TimeLib.h>
 #include <config.h>
 
@@ -15,43 +16,43 @@ GlobalTime::~GlobalTime() {
     delete m_timeClient;
 }
 
-GlobalTime* GlobalTime::getInstance() {
-    if(m_instance == nullptr) {
+GlobalTime *GlobalTime::getInstance() {
+    if (m_instance == nullptr) {
         m_instance = new GlobalTime();
     }
     return m_instance;
 }
 
 void GlobalTime::updateTime() {
-  if (millis() - m_updateTimer > m_oneSecond) {
-    if (m_timeZoneOffset != 0) {
-        m_timeClient->setTimeOffset(3600 * m_timeZoneOffset);
-    }
-    m_timeClient->update();
-    m_unixEpoch = m_timeClient->getEpochTime();
-    m_updateTimer = millis();
-    m_minute = minute(m_unixEpoch);
+    if (millis() - m_updateTimer > m_oneSecond) {
+        if (m_timeZoneOffset != 0) {
+            m_timeClient->setTimeOffset(3600 * m_timeZoneOffset);
+        }
+        m_timeClient->update();
+        m_unixEpoch = m_timeClient->getEpochTime();
+        m_updateTimer = millis();
+        m_minute = minute(m_unixEpoch);
 #if FORMAT_24_HOUR == true
-    m_hour = hour(m_unixEpoch);
+        m_hour = hour(m_unixEpoch);
 #else
-    m_hour = hourFormat12(m_unixEpoch);
+        m_hour = hourFormat12(m_unixEpoch);
 #endif
-    m_second = second(m_unixEpoch);
+        m_second = second(m_unixEpoch);
 
-    m_day = day(m_unixEpoch);
-    m_month = month(m_unixEpoch);
-    m_monthName = monthStr(m_month);
-    m_year = year(m_unixEpoch);
-    m_weekday = dayStr(weekday(m_unixEpoch));
-    m_time = String(m_hour) + ":" + (m_minute < 10 ? "0" + String(m_minute) : String(m_minute));
-  }
+        m_day = day(m_unixEpoch);
+        m_month = month(m_unixEpoch);
+        m_monthName = monthStr(m_month);
+        m_year = year(m_unixEpoch);
+        m_weekday = dayStr(weekday(m_unixEpoch));
+        m_time = String(m_hour) + ":" + (m_minute < 10 ? "0" + String(m_minute) : String(m_minute));
+        m_isAM = !bool(isPM(m_unixEpoch));  // invert to avoid weird name conflict
+    }
 }
 
 void GlobalTime::getHourAndMinute(int &hour, int &minute) {
     hour = m_hour;
     minute = m_minute;
 }
-
 
 int GlobalTime::getHour() {
     return m_hour;
@@ -93,11 +94,12 @@ String GlobalTime::getWeekday() {
     return m_weekday;
 }
 
+bool GlobalTime::isAM() {
+    return m_isAM;
+}
+
 void GlobalTime::setTimeZoneOffset(int tz) {
     Serial.print("Timezone Offset: ");
     Serial.println(tz);
     m_timeZoneOffset = tz;
 }
-
-
-

--- a/Info-Orbs/lib/globalTime/globalTime.cpp
+++ b/Info-Orbs/lib/globalTime/globalTime.cpp
@@ -45,7 +45,6 @@ void GlobalTime::updateTime() {
         m_year = year(m_unixEpoch);
         m_weekday = dayStr(weekday(m_unixEpoch));
         m_time = String(m_hour) + ":" + (m_minute < 10 ? "0" + String(m_minute) : String(m_minute));
-        m_isAM = !bool(isPM(m_unixEpoch));  // invert to avoid weird name conflict
     }
 }
 
@@ -94,8 +93,8 @@ String GlobalTime::getWeekday() {
     return m_weekday;
 }
 
-bool GlobalTime::isAM() {
-    return m_isAM;
+bool GlobalTime::isPM() {
+    return hour(m_unixEpoch) >= 12;
 }
 
 void GlobalTime::setTimeZoneOffset(int tz) {

--- a/Info-Orbs/lib/globalTime/globalTime.h
+++ b/Info-Orbs/lib/globalTime/globalTime.h
@@ -2,51 +2,53 @@
 #define TIME_H
 
 #include <NTPClient.h>
-#include <WiFiUdp.h>
 #include <TimeLib.h>
+#include <WiFiUdp.h>
 #include <config.h>
 
 class GlobalTime {
-public:
-  static GlobalTime* getInstance();
+   public:
+    static GlobalTime *getInstance();
 
-  void updateTime();
-  void getHourAndMinute(int &hour, int &minute);
-  int getHour();
-  int getMinute();
-  time_t getUnixEpoch();
-  int getSecond();
-  int getDay();
-  int getMonth();
-  String getMonthName();
-  int getYear();
-  String getTime();
-  String getWeekday();
-  void setTimeZoneOffset(int tz);
+    void updateTime();
+    void getHourAndMinute(int &hour, int &minute);
+    int getHour();
+    int getMinute();
+    time_t getUnixEpoch();
+    int getSecond();
+    int getDay();
+    int getMonth();
+    String getMonthName();
+    int getYear();
+    String getTime();
+    String getWeekday();
+    void setTimeZoneOffset(int tz);
+    bool isAM();
 
-private:
-  GlobalTime();
-  ~GlobalTime();
+   private:
+    GlobalTime();
+    ~GlobalTime();
 
-  static GlobalTime *m_instance;
+    static GlobalTime *m_instance;
 
-  time_t m_unixEpoch;
-  int m_hour = 0;
-  int m_minute = 0;
-  int m_second = 0;
-  int m_day = 0;
-  int m_month = 0;
-  String m_monthName;
-  int m_year = 0;
-  String m_time;
-  String m_weekday;
-  int m_timeZoneOffset = TIME_ZONE_OFFSET;
+    time_t m_unixEpoch;
+    int m_hour = 0;
+    int m_minute = 0;
+    int m_second = 0;
+    int m_day = 0;
+    int m_month = 0;
+    String m_monthName;
+    int m_year = 0;
+    String m_time;
+    String m_weekday;
+    int m_timeZoneOffset = TIME_ZONE_OFFSET;
+    bool m_isAM = false;
 
-  WiFiUDP m_udp;
-  NTPClient *m_timeClient{nullptr};
+    WiFiUDP m_udp;
+    NTPClient *m_timeClient{nullptr};
 
-  const int m_oneSecond{1000};
-  int m_updateTimer{0};
+    const int m_oneSecond{1000};
+    int m_updateTimer{0};
 };
 
 #endif

--- a/Info-Orbs/lib/globalTime/globalTime.h
+++ b/Info-Orbs/lib/globalTime/globalTime.h
@@ -23,7 +23,7 @@ class GlobalTime {
     String getTime();
     String getWeekday();
     void setTimeZoneOffset(int tz);
-    bool isAM();
+    bool isPM();
 
    private:
     GlobalTime();
@@ -42,7 +42,6 @@ class GlobalTime {
     String m_time;
     String m_weekday;
     int m_timeZoneOffset = TIME_ZONE_OFFSET;
-    bool m_isAM = false;
 
     WiFiUDP m_udp;
     NTPClient *m_timeClient{nullptr};

--- a/Info-Orbs/src/widgets/clockWidget.cpp
+++ b/Info-Orbs/src/widgets/clockWidget.cpp
@@ -17,7 +17,6 @@ void ClockWidget::setup() {
 }
 
 void ClockWidget::draw(bool force) {
-    GlobalTime* time = GlobalTime::getInstance();
     bool showFirstDigit = FORMAT_24_HOUR || (!FORMAT_24_HOUR && m_hourSingle >= 10);
     if ((showFirstDigit && m_lastDisplay1Didget != m_display1Didget) || force) {
         displayDidget(0, m_display1Didget, 7, 5, FOREGROUND_COLOR);
@@ -55,7 +54,7 @@ void ClockWidget::displayAmPm(uint32_t color) {
     TFT_eSPI& display = m_manager.getDisplay();
     display.setTextSize(4);
     display.setTextColor(color, TFT_BLACK, true);
-    const String& am_pm = time->isPM() ? "PM" : "AM";
+    String am_pm = time->isPM() ? "PM" : "AM";
     display.drawString(am_pm, SCREEN_SIZE - 50, SCREEN_SIZE / 2, 1);
 }
 

--- a/Info-Orbs/src/widgets/clockWidget.cpp
+++ b/Info-Orbs/src/widgets/clockWidget.cpp
@@ -18,7 +18,7 @@ void ClockWidget::setup() {
 
 void ClockWidget::draw(bool force) {
     GlobalTime* time = GlobalTime::getInstance();
-    bool showFirstDigit = FORMAT_24_HOUR || (!FORMAT_24_HOUR && !time->isAM());
+    bool showFirstDigit = FORMAT_24_HOUR || (!FORMAT_24_HOUR && time->isPM());
     if ((showFirstDigit && m_lastDisplay1Didget != m_display1Didget) || force) {
         displayDidget(0, m_display1Didget, 7, 5, FOREGROUND_COLOR);
         m_lastDisplay1Didget = m_display1Didget;
@@ -55,7 +55,7 @@ void ClockWidget::displayAmPm(uint32_t color) {
     TFT_eSPI& display = m_manager.getDisplay();
     display.setTextSize(4);
     display.setTextColor(color, TFT_BLACK, true);
-    const String& am_pm = time->isAM() ? "AM" : "PM";
+    const String& am_pm = time->isPM() ? "PM" : "AM";
     display.drawString(am_pm, SCREEN_SIZE - 50, SCREEN_SIZE / 2, 1);
 }
 

--- a/Info-Orbs/src/widgets/clockWidget.cpp
+++ b/Info-Orbs/src/widgets/clockWidget.cpp
@@ -17,7 +17,8 @@ void ClockWidget::setup() {
 }
 
 void ClockWidget::draw(bool force) {
-    bool showFirstDigit = FORMAT_24_HOUR || (!FORMAT_24_HOUR && m_hourSingle >= 10);
+    GlobalTime* time = GlobalTime::getInstance();
+    bool showFirstDigit = FORMAT_24_HOUR || (!FORMAT_24_HOUR && !time->isAM());
     if ((showFirstDigit && m_lastDisplay1Didget != m_display1Didget) || force) {
         displayDidget(0, m_display1Didget, 7, 5, FOREGROUND_COLOR);
         m_lastDisplay1Didget = m_display1Didget;
@@ -49,11 +50,12 @@ void ClockWidget::draw(bool force) {
 }
 
 void ClockWidget::displayAmPm(uint32_t color) {
+    GlobalTime* time = GlobalTime::getInstance();
     m_manager.selectScreen(2);
     TFT_eSPI& display = m_manager.getDisplay();
     display.setTextSize(4);
     display.setTextColor(color, TFT_BLACK, true);
-    const String& am_pm = m_hourSingle >= 12 ? "AM" : "PM";
+    const String& am_pm = time->isAM() ? "AM" : "PM";
     display.drawString(am_pm, SCREEN_SIZE - 50, SCREEN_SIZE / 2, 1);
 }
 

--- a/Info-Orbs/src/widgets/clockWidget.cpp
+++ b/Info-Orbs/src/widgets/clockWidget.cpp
@@ -18,7 +18,7 @@ void ClockWidget::setup() {
 
 void ClockWidget::draw(bool force) {
     GlobalTime* time = GlobalTime::getInstance();
-    bool showFirstDigit = FORMAT_24_HOUR || (!FORMAT_24_HOUR && time->isPM());
+    bool showFirstDigit = FORMAT_24_HOUR || (!FORMAT_24_HOUR && m_hourSingle >= 10);
     if ((showFirstDigit && m_lastDisplay1Didget != m_display1Didget) || force) {
         displayDidget(0, m_display1Didget, 7, 5, FOREGROUND_COLOR);
         m_lastDisplay1Didget = m_display1Didget;
@@ -43,7 +43,7 @@ void ClockWidget::draw(bool force) {
             displayDidget(2, ":", 7, 5, BG_COLOR, false);
         }
         m_lastSecondSingle = m_secondSingle;
-        if (!FORMAT_24_HOUR) {
+        if (!FORMAT_24_HOUR && SHOW_AM_PM_INDICATOR) {
             displayAmPm(FOREGROUND_COLOR);
         }
     }


### PR DESCRIPTION
## Changes
This PR fixes the offset issue with the time provider always returning 12 when the time is past 12 pm. Instead, this switches to uses the libs `isPM` function instead.

Additionally, it adds a specific setting for showing the AM/PM indicator.

## Testing
Enable and disable the setting for the indicator to test the visibility
For very thorough testing, ensure the time is valid in both AM and PM scenarios. I will provide screenshots for both.

## Misc
![image](https://github.com/brettdottech/info-orbs/assets/6775551/f812e1a7-d0b2-4598-be46-e3016e7399d0)

