### PR TITLE
show shadow for single digit hours and clear for non-shadow

### DIFF
--- a/Info-Orbs/lib/screenManager/screenManager.cpp
+++ b/Info-Orbs/lib/screenManager/screenManager.cpp
@@ -46,9 +46,15 @@ void ScreenManager::fillAllScreens(uint32_t color) {
   reset();
 }
 
-// clears all screens but resetting them to black
+// clears all screens by resetting them to black
 void ScreenManager::clearAllScreens() {
   fillAllScreens(TFT_BLACK);
+}
+
+// clears one screens by resetting it to black
+void ScreenManager::clearScreen(int screen) {
+  selectScreen(screen);
+  m_tft.fillScreen(TFT_BLACK);
 }
 
 // Selects all screens

--- a/Info-Orbs/lib/screenManager/screenManager.h
+++ b/Info-Orbs/lib/screenManager/screenManager.h
@@ -23,6 +23,8 @@ public:
     void fillAllScreens(uint32_t color);
     void clearAllScreens();
 
+    void clearScreen(int screen);
+
 private:
     uint8_t m_screen_cs[5] = {SCREEN_1_CS, SCREEN_2_CS, SCREEN_3_CS, SCREEN_4_CS, SCREEN_5_CS};
     TFT_eSPI& m_tft;

--- a/Info-Orbs/src/widgets/clockWidget.cpp
+++ b/Info-Orbs/src/widgets/clockWidget.cpp
@@ -75,7 +75,7 @@ void ClockWidget::update(bool force) {
         if (m_hourSingle < 10) {
             m_display1Didget = " ";
         } else {
-            m_display1Didget = "1";
+            m_display1Didget = int(m_hourSingle/10);
         }
         m_display2Didget = m_hourSingle % 10;
 

--- a/Info-Orbs/src/widgets/clockWidget.cpp
+++ b/Info-Orbs/src/widgets/clockWidget.cpp
@@ -17,10 +17,12 @@ void ClockWidget::setup() {
 }
 
 void ClockWidget::draw(bool force) {
-    bool showFirstDigit = FORMAT_24_HOUR || (!FORMAT_24_HOUR && m_hourSingle >= 10);
-    if ((showFirstDigit && m_lastDisplay1Didget != m_display1Didget) || force) {
+    if (m_lastDisplay1Didget != m_display1Didget || force) {
         displayDidget(0, m_display1Didget, 7, 5, FOREGROUND_COLOR);
         m_lastDisplay1Didget = m_display1Didget;
+        if (SHADOWING != 1 &&m_display1Didget == " ") {
+            m_manager.clearScreen(0);
+        }
     }
     if (m_lastDisplay2Didget != m_display2Didget || force) {
         displayDidget(1, m_display2Didget, 7, 5, FOREGROUND_COLOR);
@@ -65,14 +67,17 @@ void ClockWidget::update(bool force) {
 
     GlobalTime* time = GlobalTime::getInstance();
     m_hourSingle = time->getHour();
+
     m_minuteSingle = time->getMinute();
     m_secondSingle = time->getSecond();
 
     if (m_lastHourSingle != m_hourSingle || force) {
-        String currentHourPadded = String(m_hourSingle).length() == 1 ? " " + String(m_hourSingle) : String(m_hourSingle);
-
-        m_display1Didget = currentHourPadded.substring(0, 1);
-        m_display2Didget = currentHourPadded.substring(1, 2);
+        if (m_hourSingle < 10) {
+            m_display1Didget = " ";
+        } else {
+            m_display1Didget = "1";
+        }
+        m_display2Didget = m_hourSingle % 10;
 
         m_lastHourSingle = m_hourSingle;
     }


### PR DESCRIPTION
This fixes a bug where the transition from a double digit hour to a single digit hour did not clear the first digit. and restores the shadow on the first digit.

This also adds a call to ScreenManager to clear a single display.