### PR TITLE
Remove usage of stringstreams to reduce the binary size

### DIFF
--- a/Info-Orbs/include/utils.h
+++ b/Info-Orbs/include/utils.h
@@ -11,6 +11,7 @@ class Utils {
     static int getWrappedLines(String (&lines)[MAX_WRAPPED_LINES], String str, int limit);
     static String getWrappedLine(String str, int limit, int lineNum, int maxLines);
     static int32_t stringToColor(String color);
+    static String formatFloat(float value, int8_t digits);
 };
 
 #endif

--- a/Info-Orbs/include/widgets/stockDataModel.h
+++ b/Info-Orbs/include/widgets/stockDataModel.h
@@ -4,7 +4,6 @@
 #include <Arduino.h>
 
 #include <iomanip>
-#include <sstream>
 
 class StockDataModel {
    public:

--- a/Info-Orbs/include/widgets/weatherDataModel.h
+++ b/Info-Orbs/include/widgets/weatherDataModel.h
@@ -3,7 +3,6 @@
 
 #include <Arduino.h>
 #include <iomanip>
-#include <sstream>
 
 #define NaN -1024.0
 class WeatherDataModel {

--- a/Info-Orbs/src/core/utils.cpp
+++ b/Info-Orbs/src/core/utils.cpp
@@ -131,3 +131,11 @@ int32_t Utils::stringToColor(String color) {
         return TFT_BLACK;
     }
 }
+
+String Utils::formatFloat(float value, int8_t digits)
+{
+    char tmp[30] = {};
+    dtostrf(value, 1, digits, tmp);
+    return tmp;
+}
+

--- a/Info-Orbs/src/widgets/stockDataModel.cpp
+++ b/Info-Orbs/src/widgets/stockDataModel.cpp
@@ -1,5 +1,5 @@
 #include "widgets/stockDataModel.h"
-
+#include "utils.h"
 #include <config.h>
 
 StockDataModel::StockDataModel() {
@@ -26,9 +26,7 @@ float StockDataModel::getCurrentPrice() {
     return m_currentPrice;
 }
 String StockDataModel::getCurrentPrice(int8_t digits) {
-    std::ostringstream stream;
-    stream << std::fixed << std::setprecision(digits) << m_currentPrice;
-    return String(stream.str().c_str());
+    return Utils::formatFloat(m_currentPrice, digits);
 }
 
 StockDataModel &StockDataModel::setVolume(float volume) {
@@ -44,9 +42,7 @@ float StockDataModel::getVolume() {
 }
 
 String StockDataModel::getVolume(int8_t digits) {
-    std::ostringstream stream;
-    stream << std::fixed << std::setprecision(digits) << m_volume;
-    return String(stream.str().c_str());
+    return Utils::formatFloat(m_volume, digits);
 }
 
 StockDataModel &StockDataModel::setPriceChange(float priceChange) {
@@ -60,9 +56,7 @@ float StockDataModel::getPriceChange() {
     return m_priceChange;
 }
 String StockDataModel::getPriceChange(int8_t digits) {
-    std::ostringstream stream;
-    stream << std::fixed << std::setprecision(digits) << m_priceChange;
-    return String(stream.str().c_str());
+    return Utils::formatFloat(m_priceChange, digits);
 }
 
 StockDataModel &StockDataModel::setPercentChange(float percentChange) {
@@ -77,9 +71,7 @@ float StockDataModel::getPercentChange() {
 }
 
 String StockDataModel::getPercentChange(int8_t digits) {
-    std::ostringstream stream;
-    stream << std::fixed << std::setprecision(digits) << m_percentChange*100;
-    return String(stream.str().c_str());
+    return Utils::formatFloat(m_percentChange*100, digits);
 }
 
 bool StockDataModel::isChanged() {

--- a/Info-Orbs/src/widgets/stockWidget.cpp
+++ b/Info-Orbs/src/widgets/stockWidget.cpp
@@ -5,7 +5,6 @@
 #include <config.h>
 
 #include <iomanip>
-#include <sstream>
 
 StockWidget::StockWidget(ScreenManager &manager) : Widget(manager) {
     char stockList[strlen(STOCK_TICKER_LIST) + 1];

--- a/Info-Orbs/src/widgets/weatherDataModel.cpp
+++ b/Info-Orbs/src/widgets/weatherDataModel.cpp
@@ -1,4 +1,5 @@
 #include "widgets/weatherDataModel.h"
+#include "utils.h"
 
 WeatherDataModel::WeatherDataModel() {
 }
@@ -52,9 +53,7 @@ float WeatherDataModel::getCurrentTemperature() {
 }
 
 String WeatherDataModel::getCurrentTemperature(int8_t digits) {
-    std::ostringstream stream;
-    stream << std::fixed << std::setprecision(digits) << m_currentWeatherDeg;
-    return String(stream.str().c_str());
+    return Utils::formatFloat(m_currentWeatherDeg, digits);
 }
 
 WeatherDataModel &WeatherDataModel::setTodayHigh(float high) {
@@ -70,9 +69,7 @@ float WeatherDataModel::getTodayHigh() {
 }
 
 String WeatherDataModel::getTodayHigh(int8_t digits) {
-    std::ostringstream stream;
-    stream << std::fixed << std::setprecision(digits) << m_todayHigh;
-    return String(stream.str().c_str());
+    return Utils::formatFloat(m_todayHigh, digits);
 }
 
 WeatherDataModel &WeatherDataModel::setTodayLow(float low) {
@@ -88,9 +85,7 @@ float WeatherDataModel::getTodayLow() {
 }
 
 String WeatherDataModel::getTodayLow(int8_t digits) {
-    std::ostringstream stream;
-    stream << std::fixed << std::setprecision(digits) << m_todayLow;
-    return String(stream.str().c_str());
+    return Utils::formatFloat(m_todayLow, digits);
 }
 
 WeatherDataModel &WeatherDataModel::setDaysIcons(String *icons) {
@@ -146,12 +141,10 @@ float WeatherDataModel::getDayLow(int num) {
 }
 
 String WeatherDataModel::getDayLow(int8_t num, int8_t digits) {
-    if (m_daysHigh[num] == NaN) {
+    if (m_daysLow[num] == NaN) {
         return "";
     }
-    std::ostringstream stream;
-    stream << std::fixed << std::setprecision(digits) << m_daysLow[num];
-    return String(stream.str().c_str());
+    return Utils::formatFloat(m_daysLow[num], digits);
 }
 
 WeatherDataModel &WeatherDataModel::setDaysHighs(float highs[3]) {
@@ -176,9 +169,7 @@ String WeatherDataModel::getDayHigh(int8_t num, int8_t digits) {
     if (m_daysHigh[num] == NaN) {
         return "";
     }
-    std::ostringstream stream;
-    stream << std::fixed << std::setprecision(digits) << m_daysHigh[num];
-    return String(stream.str().c_str());
+    return Utils::formatFloat(m_daysHigh[num], digits);
 }
 
 WeatherDataModel &WeatherDataModel::setDayHigh(int num, float high) {


### PR DESCRIPTION
Before:
```
RAM:   [==        ]  17.1% (used 56012 bytes from 327680 bytes)
Flash: [==========]  95.2% (used 1248121 bytes from 1310720 bytes)
```

After:
```
RAM:   [==        ]  15.6% (used 51140 bytes from 327680 bytes)
Flash: [========  ]  78.6% (used 1030505 bytes from 1310720 bytes)
```

-- This is a draft because I have not been able to test this on a device yet --