### PR TITLE
Spelling (didget -> digit), also Widgets now have a getName() method

### DIFF
--- a/Info-Orbs/include/core/wifiWidget.h
+++ b/Info-Orbs/include/core/wifiWidget.h
@@ -1,7 +1,8 @@
 #pragma once
 #ifndef WIFIWIDGET_H
 #define WIFIWIDGET_H
-#include "widget.h"
+
+#include <widget.h>
 
 class WifiWidget : public Widget{
 public:
@@ -11,7 +12,8 @@ public:
     void update(bool force = false) override;
     void draw(bool force = false) override;
     void changeMode() override;
-
+    String getName() override;
+    
     bool isConnected() { return m_isConnected; }
 
 private:

--- a/Info-Orbs/include/widgets/clockWidget.h
+++ b/Info-Orbs/include/widgets/clockWidget.h
@@ -12,6 +12,7 @@ class ClockWidget : public Widget {
     void update(bool force = false) override;
     void draw(bool force = false) override;
     void changeMode() override;
+    String getName() override;
 
    private:
     void displayDigit(int displayIndex, const String& digit, int font, int fontSize, uint32_t color, bool shadowing);

--- a/Info-Orbs/include/widgets/clockWidget.h
+++ b/Info-Orbs/include/widgets/clockWidget.h
@@ -14,8 +14,8 @@ class ClockWidget : public Widget {
     void changeMode() override;
 
    private:
-    void displayDidget(int displayIndex, const String& didget, int font, int fontSize, uint32_t color, bool shadowing);
-    void displayDidget(int displayIndex, const String& didget, int font, int fontSize, uint32_t color);
+    void displayDigit(int displayIndex, const String& digit, int font, int fontSize, uint32_t color, bool shadowing);
+    void displayDigit(int displayIndex, const String& digit, int font, int fontSize, uint32_t color);
     void displaySeconds(int displayIndex, int seconds, int color);
     void displayAmPm(uint32_t color);
 
@@ -37,15 +37,15 @@ class ClockWidget : public Widget {
     int m_lastHourSingle{-1};
     int m_lastSecondSingle{-1};
 
-    // Didgets
-    String m_display1Didget;
-    String m_lastDisplay1Didget{"-1"};
-    String m_display2Didget;
-    String m_lastDisplay2Didget{"-1"};
+    // Digits
+    String m_display1Digit;
+    String m_lastDisplay1Digit{"-1"};
+    String m_display2Digit;
+    String m_lastDisplay2Digit{"-1"};
     // Display 3 is :
-    String m_display4Didget;
-    String m_lastDisplay4Didget{"-1"};
-    String m_display5Didget;
-    String m_lastDisplay5Didget{"-1"};
+    String m_display4Digit;
+    String m_lastDisplay4Digit{"-1"};
+    String m_display5Digit;
+    String m_lastDisplay5Digit{"-1"};
 };
 #endif  // CLOCKWIDGET_H

--- a/Info-Orbs/include/widgets/stockWidget.h
+++ b/Info-Orbs/include/widgets/stockWidget.h
@@ -17,7 +17,8 @@ class StockWidget : public Widget {
     void update(bool force = false) override;
     void draw(bool force = false) override;
     void changeMode() override;
-
+    String getName() override;
+    
    private:
     void getStockData(StockDataModel &stock);
     void displayStock(int8_t displayIndex, StockDataModel &stock, uint32_t backgroundColor, uint32_t textColor);

--- a/Info-Orbs/include/widgets/weatherWidget.h
+++ b/Info-Orbs/include/widgets/weatherWidget.h
@@ -19,7 +19,8 @@ class WeatherWidget : public Widget {
     void update(bool force = false) override;
     void draw(bool force = false) override;
     void changeMode() override;
-
+    String getName() override;
+    
    private:
     void displayClock(int displayIndex, uint32_t background, uint32_t textColor);
 

--- a/Info-Orbs/include/widgets/webDataWidget.h
+++ b/Info-Orbs/include/widgets/webDataWidget.h
@@ -16,7 +16,8 @@ class WebDataWidget : public Widget {
     void update(bool force = false) override;
     void draw(bool force = false) override;
     void changeMode() override;
-
+    String getName() override;
+    
    private:
     int m_lastUpdate = 0;
     int m_updateDelay = 1000;

--- a/Info-Orbs/lib/widget/widget.h
+++ b/Info-Orbs/lib/widget/widget.h
@@ -12,6 +12,7 @@ public:
     virtual void update(bool force = false) = 0;
     virtual void draw(bool force = false) = 0;
     virtual void changeMode() = 0;
+    virtual String getName() = 0;
     void setBusy(bool busy);
 
 protected:

--- a/Info-Orbs/lib/widget/widgetSet.cpp
+++ b/Info-Orbs/lib/widget/widgetSet.cpp
@@ -59,25 +59,31 @@ void WidgetSet::switchWidget() {
   getCurrent()->draw(true);
 }
 
-void WidgetSet::showLoading() {
-  // display loading screen here
-    m_screenManager->fillAllScreens(TFT_BLACK);
-    m_screenManager->selectScreen(2);
+void WidgetSet::showCenteredLine(int screen, int size, String text) {
+    m_screenManager->selectScreen(screen);
 
     TFT_eSPI &display = m_screenManager->getDisplay();
 
     display.fillScreen(TFT_BLACK);
     display.setTextColor(TFT_WHITE);
-    display.setTextSize(3);  // Set text size
+    display.setTextSize(size);  // Set text size
 
     // Calculate center positions
     int centre = display.width() / 2;
-    display.drawString("Loading Data", centre, centre, 1);
+    display.drawString(text, centre, centre, 1);
+}
+
+
+void WidgetSet::showLoading() {
+    m_screenManager->fillAllScreens(TFT_BLACK);
+    
+    WidgetSet::showCenteredLine(2, 3, "Loading Data");
 }
 
 void WidgetSet::updateAll() {
   for (int8_t i; i<m_widgetCount; i++) {
     Serial.println("updating widget #" + String(i));
+    showCenteredLine(3, 3, String(i));
     m_widgets[i]->update();
   }
 }

--- a/Info-Orbs/lib/widget/widgetSet.cpp
+++ b/Info-Orbs/lib/widget/widgetSet.cpp
@@ -67,23 +67,20 @@ void WidgetSet::showCenteredLine(int screen, int size, String text) {
     display.fillScreen(TFT_BLACK);
     display.setTextColor(TFT_WHITE);
     display.setTextSize(size);  // Set text size
-
-    // Calculate center positions
-    int centre = display.width() / 2;
-    display.drawString(text, centre, centre, 1);
+    display.drawCentreString(text, 120, 100, 1);
 }
 
 
 void WidgetSet::showLoading() {
     m_screenManager->fillAllScreens(TFT_BLACK);
     
-    WidgetSet::showCenteredLine(2, 3, "Loading Data");
+    WidgetSet::showCenteredLine(2, 3, "Loading Data:");
 }
 
 void WidgetSet::updateAll() {
   for (int8_t i; i<m_widgetCount; i++) {
-    Serial.println("updating widget #" + String(i));
-    showCenteredLine(3, 3, String(i));
+    Serial.printf("updating widget %s\n", m_widgets[i]->getName().c_str());
+    showCenteredLine(3, 3, m_widgets[i]->getName().c_str());
     m_widgets[i]->update();
   }
 }

--- a/Info-Orbs/lib/widget/widgetSet.h
+++ b/Info-Orbs/lib/widget/widgetSet.h
@@ -23,6 +23,7 @@ public:
     void setClearScreensOnDrawCurrent();
 
    private:
+    void showCenteredLine(int screen, int size, String text);
     ScreenManager *m_screenManager;
     bool m_clearScreensOnDrawCurrent = true;
     Widget *m_widgets[MAX_WIDGETS];

--- a/Info-Orbs/src/core/wifiWidget.cpp
+++ b/Info-Orbs/src/core/wifiWidget.cpp
@@ -26,9 +26,6 @@ void WifiWidget::setup() {
   WiFi.begin(WIFI_SSID, WIFI_PASS);
 
   Serial.println("Connecting to WiFi..");
-
-
-
 }
 
 void WifiWidget::update(bool force) {
@@ -107,4 +104,8 @@ void WifiWidget::connectionTimedOut() {
   // m_manager.selectScreen(0);
   // display.drawCentreString("Connection", 120, 80, 1);
   // display.drawCentreString(m_connectionString, 120, 100, 1);
+}
+
+String WifiWidget::getName(){
+    return "WiFi";
 }

--- a/Info-Orbs/src/widgets/clockWidget.cpp
+++ b/Info-Orbs/src/widgets/clockWidget.cpp
@@ -136,3 +136,7 @@ void ClockWidget::displaySeconds(int displayIndex, int seconds, int color) {
         display.drawSmoothArc(SCREEN_SIZE / 2, SCREEN_SIZE / 2, 120, 110, 6 * seconds - 180, 6 * seconds - 180 + 6, color, TFT_BLACK);
     }
 }
+
+String ClockWidget::getName() {
+    return "Clock";
+}

--- a/Info-Orbs/src/widgets/clockWidget.cpp
+++ b/Info-Orbs/src/widgets/clockWidget.cpp
@@ -10,40 +10,40 @@ ClockWidget::~ClockWidget() {
 }
 
 void ClockWidget::setup() {
-    m_lastDisplay1Didget = "-1";
-    m_lastDisplay2Didget = "-1";
-    m_lastDisplay4Didget = "-1";
-    m_lastDisplay5Didget = "-1";
+    m_lastDisplay1Digit = "-1";
+    m_lastDisplay2Digit = "-1";
+    m_lastDisplay4Digit = "-1";
+    m_lastDisplay5Digit = "-1";
 }
 
 void ClockWidget::draw(bool force) {
     GlobalTime* time = GlobalTime::getInstance();
     
-    if (m_lastDisplay1Didget != m_display1Didget || force) {
-        displayDidget(0, m_display1Didget, 7, 5, FOREGROUND_COLOR);
-        m_lastDisplay1Didget = m_display1Didget;
-        if (SHADOWING != 1 &&m_display1Didget == " ") {
+    if (m_lastDisplay1Digit != m_display1Digit || force) {
+        displayDigit(0, m_display1Digit, 7, 5, FOREGROUND_COLOR);
+        m_lastDisplay1Digit = m_display1Digit;
+        if (SHADOWING != 1 &&m_display1Digit == " ") {
             m_manager.clearScreen(0);
         }
     }
-    if (m_lastDisplay2Didget != m_display2Didget || force) {
-        displayDidget(1, m_display2Didget, 7, 5, FOREGROUND_COLOR);
-        m_lastDisplay2Didget = m_display2Didget;
+    if (m_lastDisplay2Digit != m_display2Digit || force) {
+        displayDigit(1, m_display2Digit, 7, 5, FOREGROUND_COLOR);
+        m_lastDisplay2Digit = m_display2Digit;
     }
-    if (m_lastDisplay4Didget != m_display4Didget || force) {
-        displayDidget(3, m_display4Didget, 7, 5, FOREGROUND_COLOR);
-        m_lastDisplay4Didget = m_display4Didget;
+    if (m_lastDisplay4Digit != m_display4Digit || force) {
+        displayDigit(3, m_display4Digit, 7, 5, FOREGROUND_COLOR);
+        m_lastDisplay4Digit = m_display4Digit;
     }
-    if (m_lastDisplay5Didget != m_display5Didget || force) {
-        displayDidget(4, m_display5Didget, 7, 5, FOREGROUND_COLOR);
-        m_lastDisplay5Didget = m_display5Didget;
+    if (m_lastDisplay5Digit != m_display5Digit || force) {
+        displayDigit(4, m_display5Digit, 7, 5, FOREGROUND_COLOR);
+        m_lastDisplay5Digit = m_display5Digit;
     }
 
     if (m_secondSingle != m_lastSecondSingle || force) {
         if (m_secondSingle % 2 == 0) {
-            displayDidget(2, ":", 7, 5, FOREGROUND_COLOR, false);
+            displayDigit(2, ":", 7, 5, FOREGROUND_COLOR, false);
         } else {
-            displayDidget(2, ":", 7, 5, BG_COLOR, false);
+            displayDigit(2, ":", 7, 5, BG_COLOR, false);
         }
 #if SHOW_SECOND_TICKS == true        
         displaySeconds(2, m_lastSecondSingle, TFT_BLACK);
@@ -80,14 +80,14 @@ void ClockWidget::update(bool force) {
     if (m_lastHourSingle != m_hourSingle || force) {
         if (m_hourSingle < 10) {
             if (FORMAT_24_HOUR) {
-                m_display1Didget = "0";
+                m_display1Digit = "0";
             } else {
-                m_display1Didget = " ";
+                m_display1Digit = " ";
             }
         } else {
-            m_display1Didget = int(m_hourSingle/10);
+            m_display1Digit = int(m_hourSingle/10);
         }
-        m_display2Didget = m_hourSingle % 10;
+        m_display2Digit = m_hourSingle % 10;
 
         m_lastHourSingle = m_hourSingle;
     }
@@ -95,8 +95,8 @@ void ClockWidget::update(bool force) {
     if (m_lastMinuteSingle != m_minuteSingle || force) {
         String currentMinutePadded = String(m_minuteSingle).length() == 1 ? "0" + String(m_minuteSingle) : String(m_minuteSingle);
 
-        m_display4Didget = currentMinutePadded.substring(0, 1);
-        m_display5Didget = currentMinutePadded.substring(1, 2);
+        m_display4Digit = currentMinutePadded.substring(0, 1);
+        m_display5Digit = currentMinutePadded.substring(1, 2);
 
         m_lastMinuteSingle = m_minuteSingle;
     }
@@ -108,7 +108,7 @@ void ClockWidget::changeMode() {
     draw(true);
 }
 
-void ClockWidget::displayDidget(int displayIndex, const String& didget, int font, int fontSize, uint32_t color, bool shadowing) {
+void ClockWidget::displayDigit(int displayIndex, const String& digit, int font, int fontSize, uint32_t color, bool shadowing) {
     m_manager.selectScreen(displayIndex);
     TFT_eSPI& display = m_manager.getDisplay();
     display.setTextSize(fontSize);
@@ -119,11 +119,11 @@ void ClockWidget::displayDidget(int displayIndex, const String& didget, int font
     } else {
         display.setTextColor(color, TFT_BLACK);
     }
-    display.drawString(didget, SCREEN_SIZE / 2, SCREEN_SIZE / 2, font);
+    display.drawString(digit, SCREEN_SIZE / 2, SCREEN_SIZE / 2, font);
 }
 
-void ClockWidget::displayDidget(int displayIndex, const String& didget, int font, int fontSize, uint32_t color) {
-    this->displayDidget(displayIndex, didget, font, fontSize, color, SHADOWING);
+void ClockWidget::displayDigit(int displayIndex, const String& digit, int font, int fontSize, uint32_t color) {
+    this->displayDigit(displayIndex, digit, font, fontSize, color, SHADOWING);
 }
 
 void ClockWidget::displaySeconds(int displayIndex, int seconds, int color) {

--- a/Info-Orbs/src/widgets/stockWidget.cpp
+++ b/Info-Orbs/src/widgets/stockWidget.cpp
@@ -122,3 +122,7 @@ void StockWidget::displayStock(int8_t displayIndex, StockDataModel &stock, uint3
 
     display.drawString(stock.getPercentChange(2) + "%", centre, 147, 1);
 }
+
+String StockWidget::getName() {
+    return "Stock";
+}

--- a/Info-Orbs/src/widgets/weatherWidget.cpp
+++ b/Info-Orbs/src/widgets/weatherWidget.cpp
@@ -316,3 +316,7 @@ int WeatherWidget::drawDegrees(String number, int x, int y, uint8_t font, uint8_
 int WeatherWidget::getClockStamp() {
     return m_time->getHour() * 60 + m_time->getMinute();
 }
+
+String WeatherWidget::getName() {
+    return "Weather";
+}

--- a/Info-Orbs/src/widgets/webDataWidget.cpp
+++ b/Info-Orbs/src/widgets/webDataWidget.cpp
@@ -69,3 +69,7 @@ void WebDataWidget::update(bool force) {
         http.end();
     }
 }
+
+String WebDataWidget::getName() {
+    return "WebData";
+}


### PR DESCRIPTION
<sup>[3rd](https://github.com/brettdottech/info-orbs/pull/62) [time](https://github.com/brettdottech/info-orbs/pull/63)'s the charm 😅 Sorry, my bad!</sup>

Unless this was intentional(?), it's spelled digit 😉

Also Widgets now have a `getName()` method so the name of the currently loading widget can be displayed during startup (both on serial and the displays).

I do realize this should've been 2 separate PR's but I'm hoping this is fine.