### PR TITLE
config.template.h defines language, globaltime.cpp and weatherwidget use it for weekday and month

### DIFF
--- a/firmware/lib/config/config.h.template
+++ b/firmware/lib/config/config.h.template
@@ -17,6 +17,7 @@
 //#define WEB_DATA_WIDGET_URL "" // Use this to make your own widgets using an API/Webdata source
 //#define WEB_DATA_STOCK_WIDGET_URL "http://<insert host here>/stocks.php?stocks=SPY,VT,GOOG,TSLA,GME" // Use this as an alternative to the stock ticker widget
 #define WIDGET_CYCLE_DELAY 0 // Automatically cycle widgets every X ms, set to 0 to disable
+#define LOC_EN // Language selection for Month and Weekday - values are LOC_EN, LOC_DE, LOC_FR
 // ============= END CONFIG ==============================================================================
 
 

--- a/firmware/lib/globalTime/globalTime.cpp
+++ b/firmware/lib/globalTime/globalTime.cpp
@@ -3,6 +3,21 @@
 #include <TimeLib.h>
 #include <config.h>
 
+#ifdef LOC_EN
+    const char LOCALE_MONTH[12][10] = {"January","February","March","April","May","June","July","August","September","October","November","December"}; // Define english for month
+    const char LOCALE_WEEKDAY[7][11] = {"Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"}; // Define english for weekday
+#endif
+
+#ifdef LOC_DE
+   const char LOC_MONTH[12][10] = {"Januar","Februar","März","April","Mai","Juni","Juli","August","September","Oktober","November","Dezember"}; // Define german for month
+   const char LOC_WEEKDAY[7][11] = {"Sonntag","Montag","Dienstag","Mittwoch","Donnerstag","Freitag","Samstag"}; // Define german for weekday
+#endif
+
+#ifdef LOC_FR
+    const char LOCALE_MONTH[12][10] = {"Janvier", "Février", "Mars", "Avril", "Mai", "Juin", "Juillet", "Août", "Septembre", "Octobre", "Novembre", "Décembre"}; // Define french for month
+    const char LOCALE_WEEKDAY[7][11] = {"Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi", "Dimanche"}; // Define french for weekday
+#endif
+
 GlobalTime *GlobalTime::m_instance = nullptr;
 
 GlobalTime::GlobalTime() {

--- a/firmware/src/widgets/weatherWidget.cpp
+++ b/firmware/src/widgets/weatherWidget.cpp
@@ -4,6 +4,21 @@
 
 #include <config.h>
 
+#ifdef LOC_EN
+    const char LOCALE_MONTH[12][10] = {"January","February","March","April","May","June","July","August","September","October","November","December"}; // Define english for month
+    const char LOCALE_WEEKDAY[7][11] = {"Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"}; // Define english for weekday
+#endif
+
+#ifdef LOC_DE
+   const char LOC_MONTH[12][10] = {"Januar","Februar","März","April","Mai","Juni","Juli","August","September","Oktober","November","Dezember"}; // Define german for month
+   const char LOC_WEEKDAY[7][11] = {"Sonntag","Montag","Dienstag","Mittwoch","Donnerstag","Freitag","Samstag"}; // Define german for weekday
+#endif
+
+#ifdef LOC_FR
+    const char LOCALE_MONTH[12][10] = {"Janvier", "Février", "Mars", "Avril", "Mai", "Juin", "Juillet", "Août", "Septembre", "Octobre", "Novembre", "Décembre"}; // Define french for month
+    const char LOCALE_WEEKDAY[7][11] = {"Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi", "Dimanche"}; // Define french for weekday
+#endif
+
 WeatherWidget::WeatherWidget(ScreenManager &manager) : Widget(manager) {
     m_mode = MODE_HIGHS;
 }


### PR DESCRIPTION
LOC_EN, LOC_DE or LOC_FR in config file defines desired language. globaltime.cpp and weatherwidget display then the weekday and month in the selected language. Now compiles without any errors.