### PR TITLE
Improve button behaviour, switched to interrupts

### DIFF
--- a/firmware/lib/button/Button.cpp
+++ b/firmware/lib/button/Button.cpp
@@ -2,6 +2,9 @@
 #include "config.h"
 
 
+/**
+ * After calling begin() make sure to attach an interrupt handler in main.cpp that will call isrButtonChange()
+ */
 Button::Button(uint8_t pin)
     : m_pin(pin), m_lastPinLevelChange(0),
       m_pinLevel(RELEASED_LEVEL), m_state(BTN_NOTHING),
@@ -11,14 +14,14 @@ void Button::begin() {
   pinMode(m_pin, BUTTON_MODE);
 }
 
-ButtonState Button::read() {
+void Button::isrButtonChange() {
   if (millis() - m_lastPinLevelChange < DEBOUNCE_TIME) {
-    // State change still within debounce time -> ignore
-	  return m_state;
+    return;
   }
 
-  if (digitalRead(m_pin) != m_pinLevel) {
-    m_pinLevel = !m_pinLevel;
+  int newPinLevel = digitalRead(m_pin);
+  if (newPinLevel != m_pinLevel) {
+    m_pinLevel = newPinLevel;
     m_lastPinLevelChange = millis();
     if (m_pinLevel == RELEASED_LEVEL) {
       // Button was now released
@@ -37,7 +40,6 @@ ButtonState Button::read() {
     }
     m_hasChanged = true;
   }
-  return m_state;
 }
 
 bool Button::has_changed() {
@@ -49,21 +51,20 @@ bool Button::has_changed() {
 }
 
 bool Button::pressedShort() {
-  return (read() == BTN_SHORT && has_changed());
+  return (m_state == BTN_SHORT && has_changed());
 }
 
 bool Button::pressedMedium() {
-  return (read() == BTN_MEDIUM && has_changed());
+  return (m_state == BTN_MEDIUM && has_changed());
 }
 
 bool Button::pressedLong() {
-  return (read() == BTN_LONG && has_changed());
+  return (m_state == BTN_LONG && has_changed());
 }
 
 ButtonState Button::getState() {
-  ButtonState state = read();
   if (has_changed()) {
-    return state;
+    return m_state;
   } else {
     return BTN_NOTHING;
   }

--- a/firmware/lib/button/Button.cpp
+++ b/firmware/lib/button/Button.cpp
@@ -19,7 +19,7 @@ void Button::isrButtonChange() {
     return;
   }
 
-  int newPinLevel = digitalRead(m_pin);
+  bool newPinLevel = digitalRead(m_pin);
   if (newPinLevel != m_pinLevel) {
     m_pinLevel = newPinLevel;
     m_lastPinLevelChange = millis();

--- a/firmware/lib/button/Button.h
+++ b/firmware/lib/button/Button.h
@@ -15,6 +15,7 @@ class Button
 		bool pressedMedium();
 		bool pressedLong();
 		ButtonState getState();
+		void isrButtonChange();
 		
 #if BUTTON_MODE == INPUT_PULLDOWN
 		const static bool PRESSED_LEVEL = HIGH;
@@ -27,7 +28,7 @@ class Button
 #ifdef BUTTON_DEBOUNCE_TIME
 		const static unsigned long DEBOUNCE_TIME = BUTTON_DEBOUNCE_TIME;
 #else
-		const static unsigned long DEBOUNCE_TIME = 50;
+		const static unsigned long DEBOUNCE_TIME = 35;
 #endif
 #ifdef BUTTON_MEDIUM_PRESS_TIME
 		const static unsigned long MEDIUM_PRESS_TIME = BUTTON_MEDIUM_PRESS_TIME;
@@ -48,7 +49,6 @@ class Button
 		unsigned long m_lastPinLevelChange;
 		unsigned long m_pressedSince;
 
-		ButtonState read();
 		bool has_changed();
 };
 

--- a/firmware/lib/button/Button.h
+++ b/firmware/lib/button/Button.h
@@ -43,11 +43,11 @@ class Button
 
 	private:
 		uint8_t  m_pin;
-		bool     m_pinLevel;
-		ButtonState  m_state;
-		bool     m_hasChanged;
-		unsigned long m_lastPinLevelChange;
-		unsigned long m_pressedSince;
+		volatile bool     m_pinLevel;
+		volatile ButtonState  m_state;
+		volatile bool     m_hasChanged;
+		volatile unsigned long m_lastPinLevelChange;
+		volatile unsigned long m_pressedSince;
 
 		bool has_changed();
 };

--- a/firmware/lib/config/config.h.template
+++ b/firmware/lib/config/config.h.template
@@ -56,7 +56,7 @@
     #define BUTTON_RIGHT 14
 #endif
 
-#define BUTTON_DEBOUNCE_TIME 50        // Debounce buttons for X ms
+#define BUTTON_DEBOUNCE_TIME 35        // Debounce buttons for X ms
 #define BUTTON_MEDIUM_PRESS_TIME 500    // Medium press is registered after X ms
 #define BUTTON_LONG_PRESS_TIME 2000     // Long press is registered after X ms
 

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -60,8 +60,8 @@ void setupButtons() {
   buttonOK.begin();
   buttonRight.begin();
 
-  attachInterrupt(digitalPinToInterrupt(BUTTON_OK), isrButtonChangeMiddle, CHANGE);
   attachInterrupt(digitalPinToInterrupt(BUTTON_LEFT), isrButtonChangeLeft, CHANGE);
+  attachInterrupt(digitalPinToInterrupt(BUTTON_OK), isrButtonChangeMiddle, CHANGE);
   attachInterrupt(digitalPinToInterrupt(BUTTON_RIGHT), isrButtonChangeRight, CHANGE);
 }
 

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -48,15 +48,29 @@ bool tft_output(int16_t x, int16_t y, uint16_t w, uint16_t h, uint16_t *bitmap) 
 ScreenManager* sm;
 WidgetSet* widgetSet;
 
-void setup() {
+/**
+ * The ISR handlers must be static
+ */
+void isrButtonChangeLeft() { buttonLeft.isrButtonChange(); }
+void isrButtonChangeMiddle() { buttonOK.isrButtonChange(); }
+void isrButtonChangeRight() { buttonRight.isrButtonChange(); }
 
+void setupButtons() {
   buttonLeft.begin();
   buttonOK.begin();
   buttonRight.begin();
 
+  attachInterrupt(digitalPinToInterrupt(BUTTON_OK), isrButtonChangeMiddle, CHANGE);
+  attachInterrupt(digitalPinToInterrupt(BUTTON_LEFT), isrButtonChangeLeft, CHANGE);
+  attachInterrupt(digitalPinToInterrupt(BUTTON_RIGHT), isrButtonChangeRight, CHANGE);
+}
+
+void setup() {
   Serial.begin(115200);
   Serial.println();
   Serial.println("Starting up...");
+
+  setupButtons();
 
   sm = new ScreenManager(tft);
   sm->selectAllScreens();
@@ -114,10 +128,12 @@ void checkButtons() {
   // Reset cycle timer whenever a button is pressed
   if (buttonLeft.pressedShort()) {
     // Left short press cycles widgets backward
+    Serial.println("Left button short pressed -> switch to prev Widget");
     m_widgetCycleDelayPrev = millis();
     widgetSet->prev();
   } else if (buttonRight.pressedShort()) {
     // Right short press cycles widgets forward
+    Serial.println("Right button short pressed -> switch to next Widget");
     m_widgetCycleDelayPrev = millis();
     widgetSet->next();
   } else {

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -24,8 +24,8 @@ unsigned long m_widgetCycleDelay = 0;
 #endif
 unsigned long m_widgetCycleDelayPrev = 0;
 
-Button buttonOK(BUTTON_OK);
 Button buttonLeft(BUTTON_LEFT);
+Button buttonOK(BUTTON_OK);
 Button buttonRight(BUTTON_RIGHT);
 
 GlobalTime *globalTime; // Initialize the global time


### PR DESCRIPTION
I changed the button class to use interrupts.

**This should avoid this situation:**
- User presses a button
- A long running update/network request starts in the "background" (let's say it takes 3 seconds)
- User releases the button after 200ms
- The button will still be triggered as "long press", because the button release will only be noticed after 3 seconds

Using interrupts, the button duration should be registered correctly, i.e. you can press/release a button during an update and the action will be executed as soon as the CPU is not blocked anymore.

Limitation:
It will only store one button event.
E.g. if you press "right" **twice** during an update, it will switch to the next widget **once** (after the update is complete).