### PR TITLE
fix: handle the clock overflow

### DIFF
--- a/Info-Orbs/include/widgets/clockWidget.h
+++ b/Info-Orbs/include/widgets/clockWidget.h
@@ -23,7 +23,7 @@ class ClockWidget : public Widget {
     int m_timeZoneOffset;
 
     // Delays for setting how often certain screens/functions are refreshed/checked. These include both the frequency which they need to be checked and a varibale to store the last checked value.
-    long m_secondTimer = 2000;  // this time is used to refressh/check the clock every second.
+    long m_secondTimer = 1000;  // this time is used to refressh/check the clock every second.
     long m_secondTimerPrev = 0;
 
     // WiFiUDP m_udp;

--- a/Info-Orbs/src/widgets/clockWidget.cpp
+++ b/Info-Orbs/src/widgets/clockWidget.cpp
@@ -67,9 +67,21 @@ void ClockWidget::displayAmPm(uint32_t color) {
 }
 
 void ClockWidget::update(bool force) {
-    if (millis() - m_secondTimerPrev < m_secondTimer && !force) {
-        return;
-    }
+    unsigned long currentMillis = millis();
+    unsigned long elapsedMillis;
+
+// Handle millis() overflow
+if (currentMillis < m_secondTimerPrev) {
+    elapsedMillis = (ULONG_MAX - m_secondTimerPrev) + currentMillis + 1;
+} else {
+    elapsedMillis = currentMillis - m_secondTimerPrev;
+}
+
+if (elapsedMillis < m_secondTimer && !force) {
+    return;
+}
+
+    m_secondTimerPrev = currentMillis;
 
     GlobalTime* time = GlobalTime::getInstance();
     m_hourSingle = time->getHour();


### PR DESCRIPTION
This PR addresses the handling of time intervals and potential overflow of the millis() function in the clockWidget.cpp file. The changes ensure accurate time calculations even when the millis() function wraps around to zero after reaching its maximum value.

These changes ensure that the timing logic in clockWidget.cpp is robust against the overflow of the millis() function, providing accurate time interval calculations.