### PR TITLE
chore: fix typo in WEATHER_LOCATION

### DIFF
--- a/Info-Orbs/include/widgets/weatherWidget.h
+++ b/Info-Orbs/include/widgets/weatherWidget.h
@@ -44,7 +44,7 @@ class WeatherWidget : public Widget {
 
     WeatherDataModel model;
 
-    String weatherLocation = WEATHER_LOCAION;
+    String weatherLocation = WEATHER_LOCATION;
 #ifdef WEATHER_UNITS_METRIC
     String weatherUnits = "metric";
 #else

--- a/Info-Orbs/lib/config/config.h.template
+++ b/Info-Orbs/lib/config/config.h.template
@@ -6,7 +6,7 @@
 #define WIFI_SSID "WIFINAME" // wifi name (please use 2.4gz network)
 #define WIFI_PASS "WIFIPASS" // wifi password
 #define TIMEZONE_API_LOCATION "America/Vancouver" // Use timezone from this list: https://timezonedb.com/time-zones
-#define WEATHER_LOCAION "Victoria, BC" //city/state for the weather
+#define WEATHER_LOCATION "Victoria, BC" //city/state for the weather
 #define STOCK_TICKER_LIST "SPY,VT,GOOG,TSLA,GME" // Choose your 5 stokcs to display on the stock tracker
 #define WEATHER_UNITS_METRIC //Comment this line out(or delete it) if you want imperial units for the weather
 #define FORMAT_24_HOUR false // toggle 24 hour clock vs 12 hour clock, chnage between true/false

--- a/Info-Orbs/src/widgets/weatherWidget.cpp
+++ b/Info-Orbs/src/widgets/weatherWidget.cpp
@@ -32,7 +32,7 @@ void WeatherWidget::draw(bool force) {
         m_clockStamp = clockStamp;
     }
 
-    // Weather, displays a clock, city & text weather discription, weather icon, temp, 3 day forecast
+    // Weather, displays a clock, city & text weather description, weather icon, temp, 3 day forecast
     if (force || model.isChanged()) {
         weatherText(1, TFT_WHITE, TFT_BLACK);
         drawWeatherIcon(model.getCurrentIcon(), 2, 0, 0, 1);
@@ -154,7 +154,7 @@ void WeatherWidget::showJPG(int displayIndex, int x, int y, const byte jpgData[]
     TJpgDec.drawJpg(x, y, jpgData, jpgDataSize);
 }
 
-// This takes the text output form the weatehr API and maps it to arespective icon/byte aarray, then displays it,
+// This takes the text output form the weather API and maps it to arespective icon/byte aarray, then displays it,
 void WeatherWidget::drawWeatherIcon(String condition, int displayIndex, int x, int y, int scale) {
     const byte *icon = NULL;
     int size = 0;
@@ -209,14 +209,14 @@ void WeatherWidget::singleWeatherDeg(int displayIndex, uint32_t backgroundColor,
     drawDegrees(model.getTodayLow(0), 160, 210, 1, 2, 4, 2, TFT_WHITE, TFT_BLACK);
 }
 
-// This displays the users current city and the text desctiption of the weather. Pass in display number, background color, text color
+// This displays the users current city and the text description of the weather. Pass in display number, background color, text color
 void WeatherWidget::weatherText(int displayIndex, int16_t b, int16_t t) {
     m_manager.selectScreen(displayIndex);
     TFT_eSPI &display = m_manager.getDisplay();
     //=== TEXT OVERFLOW ============================
     // this takes a given string a and breaks it down in max x character long strings ensuring not to break it only at a space.
-    // given the small width of the screens this will porbablly be needed to this project again so making sure to outline it
-    // clearly as this should liekly eventually be turned into a fucntion. Before use the array size should be made to be dynamic.
+    // given the small width of the screens this will probably be needed to this project again so making sure to outline it
+    // clearly as this should likely eventually be turned into a function. Before use the array size should be made to be dynamic.
     // In this case its used for the weather text description
 
     String message = model.getCurrentText() + " ";

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Info Orbs is a desk display widget built on top of an ESP32 with the intention of creating a large library of widgets/functionality!
 
-Quick Links: [Get A Dev Kit Here](https://brett.tech/collections/electronics-projects/products/info-orbs-full-dev-kit) | [Discord](https://link.brett.tech/discord) | [Youtube Assembly/Flashing Video](https://link.brett.tech/orbsYT) 
+Quick Links: [Get A Dev Kit Here](https://brett.tech/collections/electronics-projects/products/info-orbs-full-dev-kit) | [Discord](https://link.brett.tech/discord) | [Youtube Assembly/Flashing Video](https://link.brett.tech/orbsYT)
 <p>
     <img src="references/weather.png" alt="Weather Widget" style="width:30%;">
     <img src="references/time.png" alt="Clock Widget" style="width: 30%;">
@@ -12,31 +12,31 @@ Quick Links: [Get A Dev Kit Here](https://brett.tech/collections/electronics-pro
 
 ## First, a few housekeeping items for anyone interested in helping with this project, or building one for themselves
 
-- If you want to contribute and or need a hand with setup, please pop over to the [Discord](https://link.brett.tech/discord). Make sure to select you're there for info orbs when filling out the onboarding questionnaire in order to get placed in the right channels 
+- If you want to contribute and or need a hand with setup, please pop over to the [Discord](https://link.brett.tech/discord). Make sure to select you're there for info orbs when filling out the onboarding questionnaire in order to get placed in the right channels
 
 - I've put together dev kits consisting of all the parts you need to build this project [you can buy them here.](https://brett.tech/collections/electronics-projects/products/info-orbs-full-dev-kit)  They're $55 and will save you a bunch of time and hassle, and are a great way to support the project (:
 
 - I've put together a brief [Youtube Video](https://link.brett.tech/orbsYT) walking through the soldering and flashing for anyone that needs a hand assembling.
 ## Getting Up And Running
 
-### 1. Hardware/Wiring 
+### 1. Hardware/Wiring
 If you use the PCB soldering should be straight forward, however if you want to wire thing up yourself the pinouts are below:
 
     DSP-----ESP
-    SDA -> G17 
-    SCLK -> G23 
-    DC -> G19 
+    SDA -> G17
+    SCLK -> G23
+    DC -> G19
     RST -> G18
-    VCC - >5V/VCC 
+    VCC - >5V/VCC
     GND -> GND
     Screen1 CS -> G13
     Screen2 CS -> G33
-    Screen3 CS -> G32 
+    Screen3 CS -> G32
     Screen4 CS -> G25
     Screen5 CS -> G21
-   
+
    Lastly, three pushbuttons between `VCC/5V` and `G14,G26,G27.`
-Diagram can be seen below: 
+Diagram can be seen below:
 <img src="references/wiringDiag.png" alt="Wiring Diagram">
 
 
@@ -55,7 +55,7 @@ Lastly, open up the `config.h` file you just copied/renamed and adjust the below
 #define WIFI_SSID "WIFINAME" // wifi name (please use 2.4gz network)
 #define WIFI_PASS "WIFIPASS" // wifi password
 #define TIMEZONE_API_LOCATION "America/Vancouver" // Use timezone from this list: https://timezonedb.com/time-zones
-#define WEATHER_LOCAION "Victoria, BC" //city/state for the weather
+#define WEATHER_LOCATION "Victoria, BC" //city/state for the weather
 #define STOCK_TICKER_LIST "SPY,VT,GOOG,TSLA,GME" // Choose your 5 stokcs to display on the stock tracker
 #define WEATHER_UNITS_METRIC //Comment this line out(or delete it) if you want imperial units for the weather
 #define FORMAT_24_HOUR false // toggle 24 hour clock vs 12 hour clock, chnage between true/false
@@ -65,7 +65,7 @@ Lastly, open up the `config.h` file you just copied/renamed and adjust the below
 // ============= END CONFIG ==============================================================================
 ```
 
-    
+
 The code should now compile and flash to your ESP by clicking the flash button at the bottom of your IDE (:
 The left and right buttons will change between widgets, and the middle button will toggle the widgets "mode"(24/48 hour clock, high/low for weather, etc)
 


### PR DESCRIPTION
breaking change
WEATHER_LOCAION -> WEATHER_LOCATION

Hope the trailing whitespace removal in the README isn't upsetting anyone.