### PR TITLE
Bugfix Weatherwidget always refreshing data when selected

### DIFF
--- a/firmware/include/widgets/weatherWidget.h
+++ b/firmware/include/widgets/weatherWidget.h
@@ -42,8 +42,8 @@ private:
     uint16_t m_invertedForegroundColor;
     uint16_t m_invertedBackgroundColor;
 
-    const long m_updateDelay = 600000;  // Weather refresh rate
-    unsigned long m_lastUpdate = 0;
+    const long m_weatherDelay = 600000;  // Weather refresh rate
+    unsigned long m_weatherDelayPrev = 0;
 
     const int centre = 120;  // Centre location of the screen(240x240)
 

--- a/firmware/src/widgets/weatherWidget.cpp
+++ b/firmware/src/widgets/weatherWidget.cpp
@@ -36,7 +36,6 @@ void WeatherWidget::buttonPressed(uint8_t buttonId, ButtonState state) {
 }
 
 void WeatherWidget::setup() {
-    m_lastUpdate = millis() - m_updateDelay + 1000;
     m_time = GlobalTime::getInstance();
 #ifdef WEATHER_SCREEN_MODE
     m_screenMode = WEATHER_SCREEN_MODE;
@@ -63,7 +62,7 @@ void WeatherWidget::draw(bool force) {
 }
 
 void WeatherWidget::update(bool force) {
-    if (force || m_lastUpdate == 0 || (millis() - m_lastUpdate) >= m_updateDelay) {
+    if (force || m_weatherDelayPrev == 0 || (millis() - m_weatherDelayPrev) >= m_weatherDelay) {
         setBusy(true);
         if (force) {
             int retry = 0;
@@ -73,7 +72,7 @@ void WeatherWidget::update(bool force) {
             getWeatherData();
         }
         setBusy(false);
-        m_lastUpdate = millis();
+        m_weatherDelayPrev = millis();
     }
 }
 


### PR DESCRIPTION
Everytime you switch to the weather widget, the data get's reloaded, regardsless of the set refresh time of e.g. 600000 miliseconds which is 10 Minutes. This change fixes this.