### PR TITLE
Add .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ firmware/config/config.h
 # VS Code
 .vscode/
 
-.vscode/extensions.json
+# Jetbrains IDE
+.idea/
 
 megalinter-reports/


### PR DESCRIPTION
Added .idea/ to .gitignore (for Jetbrains IDEs like CLion).

Removed .vscode/extensions.json because the whole .vscode/ dir is excluded.