### PR TITLE
Switch Highs/Lows only redraw 5th screen

### DIFF
--- a/firmware/src/widgets/weatherwidget/WeatherWidget.cpp
+++ b/firmware/src/widgets/weatherwidget/WeatherWidget.cpp
@@ -27,7 +27,7 @@ void WeatherWidget::changeMode() {
     if (m_mode > MODE_LOWS) {
         m_mode = MODE_HIGHS;
     }
-    draw(true);
+    threeDayWeather(4);
 }
 
 void WeatherWidget::buttonPressed(uint8_t buttonId, ButtonState state) {


### PR DESCRIPTION
Currently when switching between Highs/Lows for the 3 days Forecast, all 5 screens are refreshed. With the TTF Font it is slow and not needed. Only the 5th screen needs to be refreshed.