### PR TITLE
Retry wifi connections. #137

### DIFF
--- a/firmware/src/widgets/wifiwidget/WifiWidget.cpp
+++ b/firmware/src/widgets/wifiwidget/WifiWidget.cpp
@@ -53,6 +53,9 @@ void WifiWidget::setup() {
     // so each Info-Orbs has a unique SSID
     m_apssid = "Info-Orbs_" + WiFi.macAddress().substring(15);
 
+    wifimgr.setCleanConnect(true);
+    wifimgr.setConnectRetries(5);
+
     // WiFiManager automatically connects using saved credentials...
     if (wifimgr.autoConnect(m_apssid.c_str())) {
         Serial.print("WifiManager connected.");


### PR DESCRIPTION
Per #137 . Tested locally. It doesn't _always_ work: sometimes it (says) it gets 0.0.0.0 IP address

```
*wm:Connect Wifi, ATTEMPT # 2 of 5
*wm:Connecting to SAVED AP: iot
*wm:connectTimeout not set, ESP waitForConnectResult... 
*wm:Connect Wifi, ATTEMPT # 3 of 5
*wm:Connecting to SAVED AP: iot
E (8233) wifi:sta is connecting, return error
[  3905][E][WiFiSTA.cpp:317] begin(): connect failed! 0x3007
*wm:connectTimeout not set, ESP waitForConnectResult... 
*wm:Connect Wifi, ATTEMPT # 4 of 5
*wm:Connecting to SAVED AP: iot
E (8866) wifi:sta is connecting, return error
[  4538][E][WiFiSTA.cpp:317] begin(): connect failed! 0x3007
*wm:connectTimeout not set, ESP waitForConnectResult... 
*wm:Connect Wifi, ATTEMPT # 5 of 5
*wm:Connecting to SAVED AP: iot
*wm:connectTimeout not set, ESP waitForConnectResult... 
*wm:AutoConnect: SUCCESS 
*wm:STA IP Address:
WifiManager connected.IP address: 0.0.0.0
```

But actually gets a real IP address (and works).

