### PR TITLE
weathertext truncates data

### DIFF
--- a/firmware/src/widgets/weatherwidget/WeatherWidget.cpp
+++ b/firmware/src/widgets/weatherwidget/WeatherWidget.cpp
@@ -230,14 +230,14 @@ void WeatherWidget::weatherText(int displayIndex) {
     String message = model.getCurrentText() + " ";
     String messageArr[4];
     int variableRangeS = 0;
-    int variableRangeE = 18;
+    int variableRangeE = 24;
     for (int i = 0; i < 4; i++) {
         while (message.substring(variableRangeE - 1, variableRangeE) != " ") {
             variableRangeE--;
         }
         messageArr[i] = message.substring(variableRangeS, variableRangeE);
         variableRangeS = variableRangeE;
-        variableRangeE = variableRangeS + 18;
+        variableRangeE = variableRangeS + 24;
     }
     //=== OVERFLOW END ==============================
 
@@ -248,7 +248,7 @@ void WeatherWidget::weatherText(int displayIndex) {
     m_manager.setFontColor(m_foregroundColor);
     m_manager.drawFittedString(cityName, centre, 80, 210, 50, Align::MiddleCenter);
 
-    auto y = 125;
+    auto y = 115;
     for (auto i = 0; i < 4; i++) {
         m_manager.drawCentreString(messageArr[i], centre, y, 15);
         y += 25;


### PR DESCRIPTION
With the current settings for character length 18 the weather text does not fit on the screen and is truncated. Instead i use 24 characters per line and also the start line is on 115 instead of 125.

![before](https://github.com/user-attachments/assets/5c089cc8-6f27-49b5-8a68-b135ae6f6c76)
![after](https://github.com/user-attachments/assets/791b784e-7728-445c-b188-c8df76855c83)
