### PR TITLE
Support Orb Rotation (and fix a button bug)

### DIFF
--- a/firmware/config/config.h.template
+++ b/firmware/config/config.h.template
@@ -5,7 +5,7 @@
 
 // MAIN CONFIGURATION
 #define TIMEZONE_API_LOCATION "America/Vancouver" // Use timezone from this list: https://timezonedb.com/time-zones
-#define INVERTED_ORBS false                       // Set to true if using InfoOrbs upside down. Inverts screens and re-orders screens and buttons.
+#define ORB_ROTATION 0                            // 0 = Normal, 1 = 90 degrees CW, 2 = 180 degrees, 3 = 270 degrees CW
 #define WIDGET_CYCLE_DELAY 0                      // Automatically cycle widgets every X seconds, set to 0 to disable
 #define LOCALE EN                                 // Language selection for Month and Weekday - possible values are EN, DE, FR
 
@@ -97,15 +97,9 @@
 #define SCREEN_4_CS 25
 #define SCREEN_5_CS 21
 
-#if INVERTED_ORBS
-    #define BUTTON_OK 27
-    #define BUTTON_LEFT 14
-    #define BUTTON_RIGHT 26
-#else
-    #define BUTTON_OK 27
-    #define BUTTON_LEFT 26
-    #define BUTTON_RIGHT 14
-#endif
+#define BUTTON_LEFT_PIN 26
+#define BUTTON_MIDDLE_PIN 27
+#define BUTTON_RIGHT_PIN 14
 
 #define BUTTON_DEBOUNCE_TIME 35        // Debounce buttons for X ms
 #define BUTTON_MEDIUM_PRESS_TIME 500    // Medium press is registered after X ms

--- a/firmware/src/core/button/Button.cpp
+++ b/firmware/src/core/button/Button.cpp
@@ -4,12 +4,12 @@
 /**
  * After calling begin() make sure to attach an interrupt handler in main.cpp that will call isrButtonChange()
  */
-Button::Button(uint8_t pin)
-    : m_pin(pin), m_lastPinLevelChange(0),
-      m_pinLevel(RELEASED_LEVEL), m_state(BTN_NOTHING),
-      m_hasChanged(false) {}
+Button::Button() : m_lastPinLevelChange(0),
+                   m_pinLevel(RELEASED_LEVEL), m_state(BTN_NOTHING),
+                   m_hasChanged(false) {}
 
-void Button::begin() {
+void Button::begin(uint8_t pin) {
+    m_pin = pin;
     pinMode(m_pin, BUTTON_MODE);
 }
 

--- a/firmware/src/core/button/Button.h
+++ b/firmware/src/core/button/Button.h
@@ -10,10 +10,11 @@ enum ButtonState {
 };
 
 enum Buttons {
-    BUTTON_LEFT = 0,
-    BUTTON_MIDDLE = 1,
-    BUTTON_OK = 1, // backwards compatibility
-    BUTTON_RIGHT = 2,
+    BUTTON_INVALID = 0,
+    BUTTON_LEFT = 1,
+    BUTTON_MIDDLE = 2,
+    BUTTON_OK = 2, // backwards compatibility
+    BUTTON_RIGHT = 3,
 };
 
 class Button {

--- a/firmware/src/core/button/Button.h
+++ b/firmware/src/core/button/Button.h
@@ -9,10 +9,17 @@ enum ButtonState {
     BTN_LONG
 };
 
+enum Buttons {
+    BUTTON_LEFT = 0,
+    BUTTON_MIDDLE = 1,
+    BUTTON_OK = 1, // backwards compatibility
+    BUTTON_RIGHT = 2,
+};
+
 class Button {
 public:
-    Button(uint8_t pin);
-    void begin();
+    Button();
+    void begin(uint8_t pin);
     bool pressedShort();
     bool pressedMedium();
     bool pressedLong();

--- a/firmware/src/core/configmanager/ConfigManager.cpp
+++ b/firmware/src/core/configmanager/ConfigManager.cpp
@@ -39,7 +39,7 @@ ConfigManager::ConfigManager(WiFiManager &wm) : m_wm(wm) {
         }
     } else {
         Serial.println("NVS initialized successfully in ConfigManager");
-        if (digitalRead(BUTTON_OK) == Button::PRESSED_LEVEL) {
+        if (digitalRead(BUTTON_MIDDLE_PIN) == Button::PRESSED_LEVEL) {
             Serial.println("Middle button pressed -> Clearing preferences...");
             m_preferences.clear();
             Serial.println("...done");

--- a/firmware/src/core/screenmanager/ScreenManager.cpp
+++ b/firmware/src/core/screenmanager/ScreenManager.cpp
@@ -13,7 +13,7 @@ ScreenManager::ScreenManager(TFT_eSPI &tft) : m_tft(tft) {
     }
 
     m_tft.init();
-    m_tft.setRotation(ConfigManager::getInstance()->getConfigBool("invertedOrbs", INVERTED_ORBS) ? 2 : 0);
+    m_tft.setRotation(ConfigManager::getInstance()->getConfigInt("orbRotation", ORB_ROTATION));
     m_tft.fillScreen(TFT_WHITE);
     m_tft.setTextDatum(MC_DATUM);
     reset();
@@ -95,7 +95,9 @@ OpenFontRender &ScreenManager::getRender() {
 // Selects a single screen
 void ScreenManager::selectScreen(int screen) {
     for (int i = 0; i < NUM_SCREENS; i++) {
-        int currentDisplay = INVERTED_ORBS ? NUM_SCREENS - i - 1 : i;
+        int orbRotation = ConfigManager::getInstance()->getConfigInt("orbRotation", ORB_ROTATION);
+        bool rotateDisplays = orbRotation == 1 || orbRotation == 2;
+        int currentDisplay = rotateDisplays ? NUM_SCREENS - i - 1 : i;
         digitalWrite(m_screen_cs[currentDisplay], i == screen ? LOW : HIGH);
     }
 }

--- a/firmware/src/core/utils/MainHelper.cpp
+++ b/firmware/src/core/utils/MainHelper.cpp
@@ -134,7 +134,7 @@ void MainHelper::handleEndpointButton() {
         uint8_t buttonId = Utils::stringToButtonId(inButton);
         ButtonState state = Utils::stringToButtonState(inState);
 
-        if (buttonId != 0 && state != BTN_NOTHING) {
+        if (buttonId != BUTTON_INVALID && state != BTN_NOTHING) {
             buttonPressed(buttonId, state);
             s_wifiManager->server->send(200, "text/plain", "OK " + inButton + "/" + inState + " -> " + String(buttonId) + "/" + String(state));
             return;

--- a/firmware/src/core/utils/Utils.cpp
+++ b/firmware/src/core/utils/Utils.cpp
@@ -339,15 +339,15 @@ const char *Utils::createConstCharBufferAndConcat(const char *prefix, const char
     return result;
 }
 
-uint8_t Utils::stringToButtonId(const String &buttonName) {
+Buttons Utils::stringToButtonId(const String &buttonName) {
     if (buttonName.equalsIgnoreCase("left")) {
         return BUTTON_LEFT;
     } else if (buttonName.equalsIgnoreCase("middle")) {
-        return BUTTON_OK;
+        return BUTTON_MIDDLE;
     } else if (buttonName.equalsIgnoreCase("right")) {
         return BUTTON_RIGHT;
     } else {
-        return 0;
+        return BUTTON_INVALID;
     }
 }
 

--- a/firmware/src/core/utils/Utils.h
+++ b/firmware/src/core/utils/Utils.h
@@ -33,7 +33,7 @@ public:
     static uint16_t grayscaleToTargetColor(uint8_t grayscale, uint8_t targetR8, uint8_t targetG8, uint8_t targetB8, float brightness, bool swapBytes = false);
     static void colorizeImageData(uint16_t *pixels565, size_t length, uint32_t targetColor888, float brightness, bool swapBytes = true);
 
-    static uint8_t stringToButtonId(const String &buttonName);
+    static Buttons stringToButtonId(const String &buttonName);
     static ButtonState stringToButtonState(const String &buttonState);
 
     /**

--- a/firmware/src/widgets/wifiwidget/WifiWidget.cpp
+++ b/firmware/src/widgets/wifiwidget/WifiWidget.cpp
@@ -22,7 +22,7 @@ void WifiWidget::setup() {
 
     // Hold right button when connecting to power to reset wifi settings
     // these are stored by the ESP WiFi library
-    if (digitalRead(BUTTON_RIGHT) == Button::PRESSED_LEVEL) {
+    if (digitalRead(BUTTON_RIGHT_PIN) == Button::PRESSED_LEVEL) {
         m_wifiManager.resetSettings();
         m_manager.drawCentreString("Wifi Settings reset", ScreenCenterX, ScreenCenterY + lineHeight, fontSize);
         delay(messageDelay);


### PR DESCRIPTION
- CHG: Removed INVERTED_ORBS from config.h, added ORB_ROTATION to config.h.
- CHG: Added ORB_ROTATION to WebPortal
- FIX: Before, the button rotation was set on compile time, now it's also set on runtime, based on ORB_ROTATION in WebPortal