### PR TITLE
Make Weather Feed pluggable

### DIFF
--- a/firmware/config/config.h.template
+++ b/firmware/config/config.h.template
@@ -38,6 +38,11 @@
 #define WEATHER_LOCATION "Victoria, BC" // City/state for the weather, look it up on https://www.visualcrossing.com/weather-data
 #define WEATHER_SCREEN_MODE Dark        // Can be either Light or Dark
 #define WEATHER_UNITS_METRIC            // Comment this line out (or delete it) if you want imperial units for the weather
+#define WEATHER_VISUALCROSSING_API_KEY "XW2RDGD6XK432AF25BNK2A3C7" // Visual Crossing API key
+//#define WEATHER_TEMPEST_FEED true
+//#define WEATHER_TEMPEST_STATION_ID "#####" // Set the station ID of your Tempest weather station
+//#define WEATHER_TEMPEST_STATION_NAME "Home" // Set the name of your Tempest weather station
+//#define WEATHER_TEMPEST_API_KEY "YOUR_API_KEY" // Your Tempest Weather API key
 
 // STOCK TICKER CONFIGURATION
 #define STOCK_TICKER_LIST "BTC/USD,USD/CAD,XEQT,SPY,APC&country=Germany" // Choose 5 securities to track. You can track forex, crypto (symbol/USD) or stocks from any exchange (if one ticker is part of multiple exchanges you can add on "&country=Canada" to narrow down to your ticker)

--- a/firmware/src/widgets/weatherwidget/WeatherFeed.h
+++ b/firmware/src/widgets/weatherwidget/WeatherFeed.h
@@ -1,0 +1,12 @@
+// include guard to ensure header is not included more than once
+#ifndef WEATHERFEED_H
+#define WEATHERFEED_H
+
+#include "WeatherDataModel.h"
+
+class WeatherFeed {
+public:
+    virtual bool getWeatherData(WeatherDataModel &model) = 0;
+};
+
+#endif // WEATHERFEED_H

--- a/firmware/src/widgets/weatherwidget/WeatherWidget.cpp
+++ b/firmware/src/widgets/weatherwidget/WeatherWidget.cpp
@@ -33,7 +33,7 @@ WeatherWidget::~WeatherWidget() {
 
 WeatherFeed* WeatherWidget::createWeatherFeed() {
 #ifdef WEATHER_TEMPEST_FEED
-    return new TempestFeed(WEATHER_TEMPEST_API_KEY, m_weatherLocation, m_weatherUnits);
+    return new TempestFeed(WEATHER_TEMPEST_API_KEY, WEATHER_TEMPEST_STATION_ID, m_weatherUnits);
 #else
     return new VisualCrossingFeed(WEATHER_VISUALCROSSING_API_KEY, m_weatherLocation, m_weatherUnits);
 #endif

--- a/firmware/src/widgets/weatherwidget/WeatherWidget.cpp
+++ b/firmware/src/widgets/weatherwidget/WeatherWidget.cpp
@@ -33,7 +33,7 @@ WeatherWidget::~WeatherWidget() {
 
 WeatherFeed* WeatherWidget::createWeatherFeed() {
 #ifdef WEATHER_TEMPEST_FEED
-    return new TempestFeed(WEATHER_TEMPEST_API_KEY, WEATHER_TEMPEST_STATION_ID, m_weatherUnits);
+    return new TempestFeed(WEATHER_TEMPEST_API_KEY, WEATHER_TEMPEST_STATION_ID, m_weatherUnits, WEATHER_TEMPEST_STATION_NAME);
 #else
     return new VisualCrossingFeed(WEATHER_VISUALCROSSING_API_KEY, m_weatherLocation, m_weatherUnits);
 #endif

--- a/firmware/src/widgets/weatherwidget/WeatherWidget.h
+++ b/firmware/src/widgets/weatherwidget/WeatherWidget.h
@@ -1,3 +1,4 @@
+// include guard to ensure header is not included more than once
 #ifndef WEATHERWIDGET_H
 #define WEATHERWIDGET_H
 
@@ -5,6 +6,12 @@
 #include "WeatherDataModel.h"
 #include "Widget.h"
 #include "config_helper.h"
+
+#ifdef WEATHER_TEMPEST_FEED
+#include "feeds/TempestFeed.h"
+#else
+#include "feeds/VisualCrossingFeed.h"
+#endif
 
 class WeatherWidget : public Widget {
 public:
@@ -25,9 +32,9 @@ private:
     void singleWeatherDeg(int displayIndex);
     void weatherText(int displayIndex);
     void threeDayWeather(int displayIndex);
-    bool getWeatherData();
     int getClockStamp();
     void configureColors();
+    WeatherFeed* createWeatherFeed();
 
     GlobalTime *m_time;
     int8_t m_mode;
@@ -50,6 +57,7 @@ private:
     int m_clockStamp = 0;
 
     WeatherDataModel model;
+    WeatherFeed *weatherFeed;
 
 // This is a hack to support old config.h files that have WEATHER_LOCAION instead of LOCATION.
 #ifndef WEATHER_LOCATION
@@ -64,9 +72,8 @@ private:
     int m_weatherUnits = 1;
 #endif
 
-    const String weatherApiKey = WEATHER_API_KEY;
-
     const int MODE_HIGHS = 0;
     const int MODE_LOWS = 1;
 };
+
 #endif // WEATHERWIDGET_H

--- a/firmware/src/widgets/weatherwidget/feeds/TempestFeed.cpp
+++ b/firmware/src/widgets/weatherwidget/feeds/TempestFeed.cpp
@@ -70,15 +70,23 @@ String TempestFeed::translateIcon(const std::string& icon) {
         {"partly-cloudy-night", "partly-cloudy-night"},
         {"cloudy", "partly-cloudy-day"},  // Map cloudy to partly-cloudy-day
         {"rain", "rain"},
+        {"rainy", "rain"},
+        {"sleet", "rain"},
         {"possibly-rain-day", "rain"},
         {"possibly-rain-night", "rain"},
+        {"possibly-sleet-day", "rain"},
+        {"possibly-sleet-night", "rain"},
         {"snow", "snow"},
         {"possibly-snow-day", "snow"},
         {"possibly-snow-night", "snow"},
         {"fog", "fog"},
+        {"foggy", "fog"},
         {"hail", "rain"},  // Example: treat hail as rain
         {"thunderstorm", "rain"},  // Example: treat thunderstorm as rain
+        {"possibly-thunderstorm-day", "rain"},  // Example: treat thunderstorm as rain
+        {"possibly-thunderstorm-night", "rain"},  // Example: treat thunderstorm as rain
         {"wind", "clear-day"},  // Example: map windy to clear-day
+        {"windy", "clear-day"},  // Example: map windy to clear-day
         {"tornado", "rain"}  // Example: treat tornado as rain
     };
 

--- a/firmware/src/widgets/weatherwidget/feeds/TempestFeed.cpp
+++ b/firmware/src/widgets/weatherwidget/feeds/TempestFeed.cpp
@@ -1,18 +1,16 @@
 #include "TempestFeed.h"
-#include "GlobalTime.h"
-#include "config_helper.h"
 #include <unordered_map>
 
 
-TempestFeed::TempestFeed(const String &apiKey, const std::string &stationId, int units)
-    : apiKey(apiKey), stationId(stationId), units(units) {}
+TempestFeed::TempestFeed(const String &apiKey, const String &stationId, int units, const String &stationName)
+    : apiKey(apiKey), stationId(stationId), units(units), stationName(stationName) {}
 
 bool TempestFeed::getWeatherData(WeatherDataModel &model) {
 
     HTTPClient http;
     String tempUnits = units == 0 ? "c" : "f";
 
-    String httpRequestAddress = "https://swd.weatherflow.com/swd/rest/better_forecast?station_id=" + String(stationId.c_str()) +
+    String httpRequestAddress = "https://swd.weatherflow.com/swd/rest/better_forecast?station_id=" + stationId +
                                 "&units_temp=" + tempUnits + "&units_wind=mph&units_pressure=mb&units_precip=in&units_distance=mi&api_key=" + apiKey;
 
     http.begin(httpRequestAddress);
@@ -36,7 +34,7 @@ bool TempestFeed::getWeatherData(WeatherDataModel &model) {
         http.end();
 
         if (!error | DeserializationError::IncompleteInput) {
-            model.setCityName(String(WEATHER_TEMPEST_STATION_NAME));
+            model.setCityName(stationName);
             model.setCurrentTemperature(doc["current_conditions"]["air_temperature"].as<float>());
             model.setCurrentText(doc["forecast"]["daily"][0]["conditions"].as<String>());
 

--- a/firmware/src/widgets/weatherwidget/feeds/TempestFeed.cpp
+++ b/firmware/src/widgets/weatherwidget/feeds/TempestFeed.cpp
@@ -1,0 +1,94 @@
+#include "TempestFeed.h"
+#include "GlobalTime.h"
+#include "config_helper.h"
+#include <unordered_map>
+
+
+TempestFeed::TempestFeed(const String &apiKey, const std::string &location, int units)
+    : apiKey(apiKey), location(location), units(units) {}
+
+bool TempestFeed::getWeatherData(WeatherDataModel &model) {
+
+    HTTPClient http;
+    String tempUnits = units == 0 ? "c" : "f";
+
+    String httpRequestAddress = "https://swd.weatherflow.com/swd/rest/better_forecast?station_id=" + String(WEATHER_TEMPEST_STATION_ID) +
+                                "&units_temp=" + tempUnits + "&units_wind=mph&units_pressure=mb&units_precip=in&units_distance=mi&api_key=" + apiKey;
+
+    http.begin(httpRequestAddress);
+    int httpCode = http.GET();
+
+    if (httpCode > 0) {
+        String payload = http.getString();
+
+        JsonDocument doc;
+        JsonDocument filter;
+                
+        filter["current_conditions"]["air_temperature"] = true;
+        filter["current_conditions"]["icon"] = true;
+        filter["forecast"]["daily"][0]["air_temp_high"] = true;
+        filter["forecast"]["daily"][0]["air_temp_low"] = true;
+        filter["forecast"]["daily"][0]["conditions"] = true;
+        filter["forecast"]["daily"][0]["icon"] = true;
+                
+        DeserializationError error = deserializeJson(doc, payload, DeserializationOption::Filter(filter));
+        
+        http.end();
+
+        if (!error | DeserializationError::IncompleteInput) {
+            model.setCityName(String(WEATHER_TEMPEST_STATION_NAME));
+            model.setCurrentTemperature(doc["current_conditions"]["air_temperature"].as<float>());
+            model.setCurrentText(doc["forecast"]["daily"][0]["conditions"].as<String>());
+
+            model.setCurrentIcon(translateIcon(doc["current_conditions"]["icon"]));
+            model.setTodayHigh(doc["forecast"]["daily"][0]["air_temp_high"].as<float>());
+            model.setTodayLow(doc["forecast"]["daily"][0]["air_temp_low"].as<float>());
+            for (int i = 0; i < 3; i++) {
+                model.setDayIcon(i, translateIcon(doc["forecast"]["daily"][i]["icon"]));
+                model.setDayHigh(i, doc["forecast"]["daily"][i]["air_temp_high"].as<float>());
+                model.setDayLow(i, doc["forecast"]["daily"][i]["air_temp_low"].as<float>());
+            }
+        } else {
+            // Handle JSON deserialization error
+            Serial.println("Deserialization failed: " + String(error.c_str()));
+            return false;
+        }
+    } else {
+        // Handle HTTP request error
+        Serial.printf("HTTP request failed, error: %s\n", http.errorToString(httpCode).c_str());
+        http.end();
+        return false;
+    }
+    return true;
+}
+
+
+String TempestFeed::translateIcon(const std::string& icon) {
+    // Define the mapping of input strings to simplified weather icons
+    static const std::unordered_map<std::string, std::string> iconMapping = {
+        {"clear-day", "clear-day"},
+        {"clear-night", "clear-night"},
+        {"partly-cloudy-day", "partly-cloudy-day"},
+        {"partly-cloudy-night", "partly-cloudy-night"},
+        {"cloudy", "partly-cloudy-day"},  // Map cloudy to partly-cloudy-day
+        {"rain", "rain"},
+        {"possibly-rain-day", "rain"},
+        {"possibly-rain-night", "rain"},
+        {"snow", "snow"},
+        {"possibly-snow-day", "snow"},
+        {"possibly-snow-night", "snow"},
+        {"fog", "fog"},
+        {"hail", "rain"},  // Example: treat hail as rain
+        {"thunderstorm", "rain"},  // Example: treat thunderstorm as rain
+        {"wind", "clear-day"},  // Example: map windy to clear-day
+        {"tornado", "rain"}  // Example: treat tornado as rain
+    };
+
+    // Find the icon in the mapping and return the corresponding simplified value
+    auto it = iconMapping.find(icon);
+    if (it != iconMapping.end()) {
+        return String(it->second.c_str());
+    }
+    return "clear-day";
+}
+

--- a/firmware/src/widgets/weatherwidget/feeds/TempestFeed.cpp
+++ b/firmware/src/widgets/weatherwidget/feeds/TempestFeed.cpp
@@ -4,15 +4,15 @@
 #include <unordered_map>
 
 
-TempestFeed::TempestFeed(const String &apiKey, const std::string &location, int units)
-    : apiKey(apiKey), location(location), units(units) {}
+TempestFeed::TempestFeed(const String &apiKey, const std::string &stationId, int units)
+    : apiKey(apiKey), stationId(stationId), units(units) {}
 
 bool TempestFeed::getWeatherData(WeatherDataModel &model) {
 
     HTTPClient http;
     String tempUnits = units == 0 ? "c" : "f";
 
-    String httpRequestAddress = "https://swd.weatherflow.com/swd/rest/better_forecast?station_id=" + String(WEATHER_TEMPEST_STATION_ID) +
+    String httpRequestAddress = "https://swd.weatherflow.com/swd/rest/better_forecast?station_id=" + String(stationId.c_str()) +
                                 "&units_temp=" + tempUnits + "&units_wind=mph&units_pressure=mb&units_precip=in&units_distance=mi&api_key=" + apiKey;
 
     http.begin(httpRequestAddress);

--- a/firmware/src/widgets/weatherwidget/feeds/TempestFeed.h
+++ b/firmware/src/widgets/weatherwidget/feeds/TempestFeed.h
@@ -8,13 +8,13 @@
 
 class TempestFeed : public WeatherFeed {
 public:
-    TempestFeed(const String &apiKey, const std::string &location, int units);
+    TempestFeed(const String &apiKey, const std::string &stationId, int units);
     bool getWeatherData(WeatherDataModel &model) override;
     String translateIcon(const std::string& icon);
     
 private:
     String apiKey;
-    std::string location;
+    std::string stationId;
     int units;
 };
 

--- a/firmware/src/widgets/weatherwidget/feeds/TempestFeed.h
+++ b/firmware/src/widgets/weatherwidget/feeds/TempestFeed.h
@@ -8,13 +8,14 @@
 
 class TempestFeed : public WeatherFeed {
 public:
-    TempestFeed(const String &apiKey, const std::string &stationId, int units);
+    TempestFeed(const String &apiKey, const String &stationId, int units, const String &stationName);
     bool getWeatherData(WeatherDataModel &model) override;
     String translateIcon(const std::string& icon);
     
 private:
     String apiKey;
-    std::string stationId;
+    String stationId;
+    String stationName;
     int units;
 };
 

--- a/firmware/src/widgets/weatherwidget/feeds/TempestFeed.h
+++ b/firmware/src/widgets/weatherwidget/feeds/TempestFeed.h
@@ -1,0 +1,21 @@
+// include guard to ensure header is not included more than once
+#ifndef TEMPESTFEED_H
+#define TEMPESTFEED_H
+
+#include "../WeatherFeed.h"
+#include <ArduinoJson.h>
+#include <HTTPClient.h>
+
+class TempestFeed : public WeatherFeed {
+public:
+    TempestFeed(const String &apiKey, const std::string &location, int units);
+    bool getWeatherData(WeatherDataModel &model) override;
+    String translateIcon(const std::string& icon);
+    
+private:
+    String apiKey;
+    std::string location;
+    int units;
+};
+
+#endif // TEMPESTFEED_H

--- a/firmware/src/widgets/weatherwidget/feeds/VisualCrossingFeed.cpp
+++ b/firmware/src/widgets/weatherwidget/feeds/VisualCrossingFeed.cpp
@@ -1,0 +1,59 @@
+#include "VisualCrossingFeed.h"
+#include "GlobalTime.h"
+#include "config_helper.h"
+
+VisualCrossingFeed::VisualCrossingFeed(const String &apiKey, const std::string &location, int units)
+    : apiKey(apiKey), location(location), units(units) {}
+
+bool VisualCrossingFeed::getWeatherData(WeatherDataModel &model) {
+    
+    Serial.println("Getting weather data from Visual Crossing");
+    
+    HTTPClient http;
+    String weatherUnits = units == 0 ? "metric" : "us";
+    String httpRequestAddress = "https://weather.visualcrossing.com/VisualCrossingWebServices/rest/services/timeline/" +
+                                String(location.c_str()) + "/next3days?key=" + apiKey + "&unitGroup=" + weatherUnits +
+                                "&include=days,current&iconSet=icons1&lang=" + LOC_LANG;
+    http.begin(httpRequestAddress);
+    int httpCode = http.GET();
+    if (httpCode > 0) {
+        // Check for the return code
+        JsonDocument filter;
+        filter["resolvedAddress"] = true;
+        filter["currentConditions"]["temp"] = true;
+        filter["days"][0]["description"] = true;
+        filter["currentConditions"]["icon"] = true;
+        filter["days"][0]["icon"] = true;
+        filter["days"][0]["tempmax"] = true;
+        filter["days"][0]["tempmin"] = true;
+
+        JsonDocument doc;
+        DeserializationError error = deserializeJson(doc, http.getString(), DeserializationOption::Filter(filter));
+        http.end();
+
+        if (!error) {
+            model.setCityName(doc["resolvedAddress"].as<String>());
+            model.setCurrentTemperature(doc["currentConditions"]["temp"].as<float>());
+            model.setCurrentText(doc["days"][0]["description"].as<String>());
+
+            model.setCurrentIcon(doc["currentConditions"]["icon"].as<String>());
+            model.setTodayHigh(doc["days"][0]["tempmax"].as<float>());
+            model.setTodayLow(doc["days"][0]["tempmin"].as<float>());
+            for (int i = 0; i < 3; i++) {
+                model.setDayIcon(i, doc["days"][i + 1]["icon"].as<String>());
+                model.setDayHigh(i, doc["days"][i + 1]["tempmax"].as<float>());
+                model.setDayLow(i, doc["days"][i + 1]["tempmin"].as<float>());
+            }
+        } else {
+            // Handle JSON deserialization error
+            Serial.println("Deserialization failed: " + String(error.c_str()));
+            return false;
+        }
+    } else {
+        // Handle HTTP request error
+        Serial.printf("HTTP request failed, error: %s\n", http.errorToString(httpCode).c_str());
+        http.end();
+        return false;
+    }
+    return true;
+}

--- a/firmware/src/widgets/weatherwidget/feeds/VisualCrossingFeed.h
+++ b/firmware/src/widgets/weatherwidget/feeds/VisualCrossingFeed.h
@@ -1,0 +1,20 @@
+// include guard to ensure header is not included more than once
+#ifndef VISUALCROSSINGFEED_H
+#define VISUALCROSSINGFEED_H
+
+#include "../WeatherFeed.h"
+#include <ArduinoJson.h>
+#include <HTTPClient.h>
+
+class VisualCrossingFeed : public WeatherFeed {
+public:
+    VisualCrossingFeed(const String &apiKey, const std::string &location, int units);
+    bool getWeatherData(WeatherDataModel &model) override;
+
+private:
+    String apiKey;
+    std::string location;
+    int units;
+};
+
+#endif // VISUALCROSSINGFEED_H


### PR DESCRIPTION
This change refactors out the getWeather method so that people can swap out the feed source if they choose to not use Visual Crossing for their weather data.  It also adds a feed for Tempest weather stations which are a popular personal weather stations.  With this change it would make it relatively easy to add other weather feeds like OpenWeatherMap, WeatherAPI, Pirate Weather, Open-Meteo, or in the US the National Weather Service.   