### PR TITLE
Update clock on fetch/update

### DIFF
--- a/firmware/src/core/utils/MainHelper.cpp
+++ b/firmware/src/core/utils/MainHelper.cpp
@@ -323,6 +323,11 @@ void MainHelper::handleEndpointFetchFilesFromURL() {
     }
 
     s_wifiManager->server->send(200, "text/html", "<h2>Files downloaded successfully!</h2><a href='/browse?dir=" + currentDir + "'>Back to file list</a>");
+
+    // Update ClockWidget (we might be showing the changed custom clock)
+    if (s_widgetSet->getCurrent()->getName() == "Clock") {
+        s_widgetSet->setClearScreensOnDrawCurrent();
+    }
 }
 
 void MainHelper::handleEndpointUploadFile() {
@@ -370,6 +375,10 @@ void MainHelper::handleEndpointUploadFile() {
             LittleFS.remove(filePath); // Clean up incomplete file
             Serial.println("Upload Aborted: " + filePath);
         }
+    }
+    // Update ClockWidget (we might be showing the changed custom clock)
+    if (s_widgetSet->getCurrent()->getName() == "Clock") {
+        s_widgetSet->setClearScreensOnDrawCurrent();
     }
 }
 


### PR DESCRIPTION
If the clock is currently on display while uploading/fetching new images, it will now update automatically to avoid showing half old/half new images. :-)