### PR TITLE
Move taskSemaphore to GlobalResources

### DIFF
--- a/firmware/src/core/utils/GlobalResources.cpp
+++ b/firmware/src/core/utils/GlobalResources.cpp
@@ -1,0 +1,55 @@
+#include "GlobalResources.h"
+
+// Define the taskSemaphore as a global variable
+SemaphoreHandle_t taskSemaphore = nullptr;
+
+void initializeGlobalResources() {
+    // Create the binary semaphore if it hasn't been created yet
+    if (!taskSemaphore) {
+        taskSemaphore = xSemaphoreCreateBinary();
+
+        // Give the semaphore initially so it can be taken by tasks
+        xSemaphoreGive(taskSemaphore);
+    }
+}
+
+/*
+ * Usage of taskSemaphore:
+ *
+ * This semaphore is intended to be used for any/all Task threads** in the application
+ * to ensure that at most only one Task thread can run at a time**. This is useful for
+ * conserving system resources, especially in resource-constrained environments like
+ * microcontrollers, where running multiple tasks concurrently could lead to excessive
+ * memory or CPU usage.
+ *
+ * 1. **Taking the Semaphore**:
+ *    - Use `xSemaphoreTake(taskSemaphore, portMAX_DELAY)` to take the semaphore.
+ *    - This will block the task until the semaphore is available.
+ *    - Example:
+ *      if (xSemaphoreTake(taskSemaphore, portMAX_DELAY) == pdTRUE) {
+ *          // Semaphore taken, proceed with the critical section
+ *      }
+ *
+ * 2. **Giving the Semaphore**:
+ *    - Use `xSemaphoreGive(taskSemaphore)` to release the semaphore after the critical section.
+ *    - Example:
+ *      xSemaphoreGive(taskSemaphore); // Release the semaphore
+ *
+ * 3. **Checking the Semaphore**:
+ *    - Use `xSemaphoreTake(taskSemaphore, 0)` to check if the semaphore is available without blocking.
+ *    - This is useful for non-blocking checks.
+ *    - Example:
+ *      if (xSemaphoreTake(taskSemaphore, 0) == pdTRUE) {
+ *          // Semaphore is available, proceed
+ *          xSemaphoreGive(taskSemaphore); // Release immediately if not needed
+ *      } else {
+ *          // Semaphore is not available
+ *      }
+ *
+ * Notes:
+ * - The semaphore is binary, so it can only be held by one task at a time.
+ * - Always ensure the semaphore is released after use to avoid deadlocks.
+ * - Use `portMAX_DELAY` for blocking waits or a specific timeout (in ticks) for timed waits.
+ * - This semaphore is **global** and should be used by all tasks that need to enforce
+ *   single-threaded execution to conserve resources.
+ */

--- a/firmware/src/core/utils/GlobalResources.h
+++ b/firmware/src/core/utils/GlobalResources.h
@@ -1,0 +1,11 @@
+#ifndef GLOBAL_RESOURCES_H
+#define GLOBAL_RESOURCES_H
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+extern SemaphoreHandle_t taskSemaphore;
+
+void initializeGlobalResources();
+
+#endif // GLOBAL_RESOURCES_H

--- a/firmware/src/core/utils/HTTPClientWrapper.h
+++ b/firmware/src/core/utils/HTTPClientWrapper.h
@@ -39,8 +39,7 @@ private:
         ResponseCallback callback;
     };
 
-    static HTTPClientWrapper* instance;
-    static SemaphoreHandle_t requestSemaphore;
+    static HTTPClientWrapper *instance;
     static QueueHandle_t requestQueue;
     static QueueHandle_t responseQueue;
     

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -1,3 +1,4 @@
+#include "GlobalResources.h"
 #include "MainHelper.h"
 #include "clockwidget/ClockWidget.h"
 #include "mqttwidget/MQTTWidget.h"
@@ -42,6 +43,8 @@ void addWidgets() {
 }
 
 void setup() {
+    // Initialize global resources
+    initializeGlobalResources();
     Serial.begin(115200);
     Serial.println();
     Serial.println("Starting up...");


### PR DESCRIPTION
The purpose of the taskSemaphore is to ensure at most only one non-mainline Task thread can run at a time to conserver/manage resource.  Moving it a GlobalResources allows it to be used easier anywhere in the app.  I also included comments as to the semaphore usage.