### PR TITLE
Publish a configurable topic when buttons are pressed

### DIFF
--- a/firmware/src/widgets/mqttwidget/MQTTWidget.h
+++ b/firmware/src/widgets/mqttwidget/MQTTWidget.h
@@ -78,6 +78,9 @@ private:
     // Data storage: maps topicSrc to latest message
     std::map<String, String> orbDataMap;
 
+    // Topic for button press
+    String buttonTopic;
+
     // Static callback proxy
     static void staticCallback(char *topic, byte *payload, unsigned int length);
 


### PR DESCRIPTION
optionally use "buttontopic" from the config message to provide a button-press topic. On button press the topic is sent a dictionary with two keys:
"button" = "invalid", "left", "middle", or "right"
"state" = "nothing", "short", "medium", or "long"
