### PR TITLE
Fix: Small bug in WebDataElementCircleModel Parser

### DIFF
--- a/firmware/src/widgets/webdatawidget/WebDataElementCircleModel.cpp
+++ b/firmware/src/widgets/webdatawidget/WebDataElementCircleModel.cpp
@@ -68,7 +68,7 @@ void WebDataElementCircleModel::parseData(const JsonObject &doc, int32_t default
     if (doc["radius"].is<int32_t>()) {
         setRadius(doc["radius"].as<int32_t>());
     }
-    if (doc["filled"].is<int32_t>()) {
+    if (doc["filled"].is<bool>()) {
         setFilled(doc["filled"].as<bool>());
     }
     if (const char *color = doc["color"]) {


### PR DESCRIPTION
Fixes a small bug in the WebDataElementCircleParser for the 'filled' field as it was checking for an integer value, where instead it should be looking for a boolean.