### PR TITLE
Include missing config_helper.h in ShowMemoryUsage

### DIFF
--- a/firmware/src/core/utils/ShowMemoryUsage.cpp
+++ b/firmware/src/core/utils/ShowMemoryUsage.cpp
@@ -1,5 +1,6 @@
 #include "ShowMemoryUsage.h"
 
+#include "config_helper.h"
 #include <Arduino.h>
 
 // initialize static members


### PR DESCRIPTION
Added the missing config_helper.h include to resolve potential dependency issues. This ensures that all necessary configurations are properly loaded for memory usage functionality.