### PR TITLE
ParqetWidget: Use a proxy to reduce JSON size

### DIFF
--- a/firmware/src/widgets/parqetwidget/ParqetHoldingDataModel.cpp
+++ b/firmware/src/widgets/parqetwidget/ParqetHoldingDataModel.cpp
@@ -5,68 +5,86 @@
 ParqetHoldingDataModel::ParqetHoldingDataModel() {
 }
 
-void ParqetHoldingDataModel::setId(String id) {
+void ParqetHoldingDataModel::setId(const String &id) {
     m_id = id;
 }
-void ParqetHoldingDataModel::setName(String name) {
+
+void ParqetHoldingDataModel::setName(const String &name) {
     m_name = name;
 }
-void ParqetHoldingDataModel::setPurchasePrice(float purchasePrice) {
+
+void ParqetHoldingDataModel::setPurchasePrice(const float purchasePrice) {
     m_purchasePrice = purchasePrice;
 }
-void ParqetHoldingDataModel::setPurchaseValue(float purchaseValue) {
+
+void ParqetHoldingDataModel::setPurchaseValue(const float purchaseValue) {
     m_purchaseValue = purchaseValue;
 }
-void ParqetHoldingDataModel::setCurrentPrice(float currentPrice) {
+
+void ParqetHoldingDataModel::setCurrentPrice(const float currentPrice) {
     m_currentPrice = currentPrice;
 }
-void ParqetHoldingDataModel::setCurrentValue(float currentValue) {
+
+void ParqetHoldingDataModel::setCurrentValue(const float currentValue) {
     m_currentValue = currentValue;
 }
-void ParqetHoldingDataModel::setShares(float shares) {
+
+void ParqetHoldingDataModel::setShares(const float shares) {
     m_shares = shares;
 }
-void ParqetHoldingDataModel::setCurrency(String currency) {
+
+void ParqetHoldingDataModel::setCurrency(const String &currency) {
     m_currency = currency;
 }
 
-void ParqetHoldingDataModel::setPerformance(float perf) {
+void ParqetHoldingDataModel::setPerformance(const float perf) {
     m_performance = perf;
 }
 
-String ParqetHoldingDataModel::getId() {
+String ParqetHoldingDataModel::getId() const {
     return m_id;
 }
-String ParqetHoldingDataModel::getName() {
+
+String ParqetHoldingDataModel::getName() const {
     return m_name;
 }
-String ParqetHoldingDataModel::getPurchasePrice(int8_t digits) {
+
+String ParqetHoldingDataModel::getPurchasePrice(const int8_t digits) const {
     return Utils::formatFloat(m_purchasePrice, digits);
 }
-String ParqetHoldingDataModel::getPurchaseValue(int8_t digits) {
+
+String ParqetHoldingDataModel::getPurchaseValue(const int8_t digits) const {
     return Utils::formatFloat(m_purchaseValue, digits);
 }
-float ParqetHoldingDataModel::getCurrentPrice() {
+
+float ParqetHoldingDataModel::getCurrentPrice() const {
     return m_currentPrice;
 }
-String ParqetHoldingDataModel::getCurrentPrice(int8_t digits) {
+
+String ParqetHoldingDataModel::getCurrentPrice(const int8_t digits) const {
     return Utils::formatFloat(m_currentPrice, digits);
 }
-float ParqetHoldingDataModel::getCurrentValue() {
+
+float ParqetHoldingDataModel::getCurrentValue() const {
     return m_currentValue;
 }
-String ParqetHoldingDataModel::getCurrentValue(int8_t digits) {
+
+String ParqetHoldingDataModel::getCurrentValue(const int8_t digits) const {
     return Utils::formatFloat(m_currentValue, digits);
 }
-String ParqetHoldingDataModel::getShares(int8_t digits) {
+
+String ParqetHoldingDataModel::getShares(const int8_t digits) const {
     return Utils::formatFloat(m_shares, digits);
 }
-float ParqetHoldingDataModel::getPerformance() {
+
+float ParqetHoldingDataModel::getPerformance() const {
     return m_performance;
 }
-String ParqetHoldingDataModel::getPerformance(int8_t digits) {
+
+String ParqetHoldingDataModel::getPerformance(const int8_t digits) const {
     return Utils::formatFloat(m_performance, digits);
 }
-String ParqetHoldingDataModel::getCurrency() {
+
+String ParqetHoldingDataModel::getCurrency() const {
     return m_currency;
 }

--- a/firmware/src/widgets/parqetwidget/ParqetHoldingDataModel.cpp
+++ b/firmware/src/widgets/parqetwidget/ParqetHoldingDataModel.cpp
@@ -30,6 +30,10 @@ void ParqetHoldingDataModel::setCurrency(String currency) {
     m_currency = currency;
 }
 
+void ParqetHoldingDataModel::setPerf(float perf) {
+    m_perf = perf;
+}
+
 String ParqetHoldingDataModel::getId() {
     return m_id;
 }
@@ -57,12 +61,11 @@ String ParqetHoldingDataModel::getCurrentValue(int8_t digits) {
 String ParqetHoldingDataModel::getShares(int8_t digits) {
     return Utils::formatFloat(m_shares, digits);
 }
-float ParqetHoldingDataModel::getPercentChange() {
-    // return 100 * (m_currentPrice-m_purchasePrice)/m_purchasePrice;
-    return 100 * (m_currentValue / m_purchaseValue - 1);
+float ParqetHoldingDataModel::getPerf() {
+    return m_perf;
 }
-String ParqetHoldingDataModel::getPercentChange(int8_t digits) {
-    return Utils::formatFloat(getPercentChange(), digits);
+String ParqetHoldingDataModel::getPerf(int8_t digits) {
+    return Utils::formatFloat(m_perf, digits);
 }
 String ParqetHoldingDataModel::getCurrency() {
     return m_currency;

--- a/firmware/src/widgets/parqetwidget/ParqetHoldingDataModel.cpp
+++ b/firmware/src/widgets/parqetwidget/ParqetHoldingDataModel.cpp
@@ -30,8 +30,8 @@ void ParqetHoldingDataModel::setCurrency(String currency) {
     m_currency = currency;
 }
 
-void ParqetHoldingDataModel::setPerf(float perf) {
-    m_perf = perf;
+void ParqetHoldingDataModel::setPerformance(float perf) {
+    m_performance = perf;
 }
 
 String ParqetHoldingDataModel::getId() {
@@ -61,11 +61,11 @@ String ParqetHoldingDataModel::getCurrentValue(int8_t digits) {
 String ParqetHoldingDataModel::getShares(int8_t digits) {
     return Utils::formatFloat(m_shares, digits);
 }
-float ParqetHoldingDataModel::getPerf() {
-    return m_perf;
+float ParqetHoldingDataModel::getPerformance() {
+    return m_performance;
 }
-String ParqetHoldingDataModel::getPerf(int8_t digits) {
-    return Utils::formatFloat(m_perf, digits);
+String ParqetHoldingDataModel::getPerformance(int8_t digits) {
+    return Utils::formatFloat(m_performance, digits);
 }
 String ParqetHoldingDataModel::getCurrency() {
     return m_currency;

--- a/firmware/src/widgets/parqetwidget/ParqetHoldingDataModel.h
+++ b/firmware/src/widgets/parqetwidget/ParqetHoldingDataModel.h
@@ -9,28 +9,28 @@ class ParqetHoldingDataModel {
 public:
     ParqetHoldingDataModel();
 
-    void setId(String id);
-    void setName(String name);
+    void setId(const String &id);
+    void setName(const String &name);
     void setPurchasePrice(float purchasePrice);
     void setPurchaseValue(float purchaseValue);
     void setCurrentPrice(float currentPrice);
     void setCurrentValue(float currentValue);
     void setShares(float shares);
-    void setCurrency(String currency);
+    void setCurrency(const String &currency);
     void setPerformance(float perf);
 
-    String getId();
-    String getName();
-    String getPurchasePrice(int8_t digits);
-    String getPurchaseValue(int8_t digits);
-    float getCurrentPrice();
-    String getCurrentPrice(int8_t digits);
-    float getCurrentValue();
-    String getCurrentValue(int8_t digits);
-    String getShares(int8_t digits);
-    String getCurrency();
-    float getPerformance();
-    String getPerformance(int8_t digits);
+    String getId() const;
+    String getName() const;
+    String getPurchasePrice(int8_t digits) const;
+    String getPurchaseValue(int8_t digits) const;
+    float getCurrentPrice() const;
+    String getCurrentPrice(int8_t digits) const;
+    float getCurrentValue() const;
+    String getCurrentValue(int8_t digits) const;
+    String getShares(int8_t digits) const;
+    String getCurrency() const;
+    float getPerformance() const;
+    String getPerformance(int8_t digits) const;
 
 private:
     String m_id = "";

--- a/firmware/src/widgets/parqetwidget/ParqetHoldingDataModel.h
+++ b/firmware/src/widgets/parqetwidget/ParqetHoldingDataModel.h
@@ -17,7 +17,7 @@ public:
     void setCurrentValue(float currentValue);
     void setShares(float shares);
     void setCurrency(String currency);
-    void setPerf(float perf);
+    void setPerformance(float perf);
 
     String getId();
     String getName();
@@ -29,8 +29,8 @@ public:
     String getCurrentValue(int8_t digits);
     String getShares(int8_t digits);
     String getCurrency();
-    float getPerf();
-    String getPerf(int8_t digits);
+    float getPerformance();
+    String getPerformance(int8_t digits);
 
 private:
     String m_id = "";
@@ -41,7 +41,7 @@ private:
     float m_currentValue = 0;
     float m_shares = 0;
     String m_currency = "";
-    float m_perf = 0;
+    float m_performance = 0;
 };
 
 #endif // PARQET_HOLDING_DATA_MODEL_H

--- a/firmware/src/widgets/parqetwidget/ParqetHoldingDataModel.h
+++ b/firmware/src/widgets/parqetwidget/ParqetHoldingDataModel.h
@@ -17,6 +17,7 @@ public:
     void setCurrentValue(float currentValue);
     void setShares(float shares);
     void setCurrency(String currency);
+    void setPerf(float perf);
 
     String getId();
     String getName();
@@ -27,9 +28,9 @@ public:
     float getCurrentValue();
     String getCurrentValue(int8_t digits);
     String getShares(int8_t digits);
-    float getPercentChange();
-    String getPercentChange(int8_t digits);
     String getCurrency();
+    float getPerf();
+    String getPerf(int8_t digits);
 
 private:
     String m_id = "";
@@ -40,6 +41,7 @@ private:
     float m_currentValue = 0;
     float m_shares = 0;
     String m_currency = "";
+    float m_perf = 0;
 };
 
 #endif // PARQET_HOLDING_DATA_MODEL_H

--- a/firmware/src/widgets/parqetwidget/ParqetWidget.cpp
+++ b/firmware/src/widgets/parqetwidget/ParqetWidget.cpp
@@ -116,13 +116,12 @@ ParqetDataModel ParqetWidget::getPortfolio() {
 
 void ParqetWidget::updatePortfolio() {
     PARQET_DEBUG_PRINT_MEM("Begin .updatePortfolio()");
-    String portfolioId = String(m_portfolioId.c_str());
-    if (portfolioId.isEmpty() || m_parquetProxyUrl.empty()) {
+    if (m_portfolioId.empty() || m_parquetProxyUrl.empty()) {
         return;
     }
-    Serial.printf("Parqet: Update Portfolio %s\n", portfolioId.c_str());
+    Serial.printf("Parqet: Update Portfolio %s\n", m_portfolioId.c_str());
     String httpRequestAddress = String(m_parquetProxyUrl.c_str());
-    httpRequestAddress += "?id=" + portfolioId + "&timeframe=" + getTimeframe() + "&perf=" + m_perfMeasures[m_curPerfMeasure] + "&perfChart=" + m_perfChartMeasures[m_curPerfChartMeasure];
+    httpRequestAddress += "?id=" + String(m_portfolioId.c_str()) + "&timeframe=" + getTimeframe() + "&perf=" + m_perfMeasures[m_curPerfMeasure] + "&perfChart=" + m_perfChartMeasures[m_curPerfChartMeasure];
 
     auto task = TaskFactory::createHttpGetTask(
         httpRequestAddress, [this](int httpCode, const String &response) {

--- a/firmware/src/widgets/parqetwidget/ParqetWidget.cpp
+++ b/firmware/src/widgets/parqetwidget/ParqetWidget.cpp
@@ -130,13 +130,13 @@ void ParqetWidget::updatePortfolio() {
         });
 
     if (!task) {
-        Serial.println("Failed to create pqValues task");
+        Serial.println("Failed to create parqet task");
         return;
     }
 
     bool success = TaskManager::getInstance()->addTask(std::move(task));
     if (!success) {
-        Serial.println("Failed to add pqValues task");
+        Serial.println("Failed to add parqet task");
         return;
     }
 }
@@ -162,30 +162,27 @@ void ParqetWidget::processResponse(int httpCode, const String &response) {
             int count = 0;
             for (JsonVariant holding : holdings) {
                 String type = holding["assetType"].as<String>();
-                if (type == "security" || type == "crypto") {
-                    // stocks or etf/funds
-                    String id = holding["id"].as<String>();
-                    String name = holding["name"].as<String>();
-                    float purchasePrice = holding["priceStart"].as<float>();
-                    float purchaseValue = holding["valueStart"].as<float>();
-                    float currentPrice = holding["priceNow"].as<float>();
-                    float currentValue = holding["valueNow"].as<float>();
-                    float shares = holding["shares"].as<float>();
-                    float perf = holding["perf"].as<float>();
-                    String currency = holding["currency"].as<String>();
-                    if (currentValue > 0) {
-                        ParqetHoldingDataModel h = ParqetHoldingDataModel();
-                        h.setId(id);
-                        h.setName(name);
-                        h.setPurchasePrice(purchasePrice);
-                        h.setPurchaseValue(purchaseValue);
-                        h.setCurrentPrice(currentPrice);
-                        h.setCurrentValue(currentValue);
-                        h.setShares(shares);
-                        h.setCurrency(currency);
-                        h.setPerf(perf);
-                        holdingArray[count++] = h;
-                    }
+                String id = holding["id"].as<String>();
+                String name = holding["name"].as<String>();
+                float purchasePrice = holding["priceStart"].as<float>();
+                float purchaseValue = holding["valueStart"].as<float>();
+                float currentPrice = holding["priceNow"].as<float>();
+                float currentValue = holding["valueNow"].as<float>();
+                float shares = holding["shares"].as<float>();
+                float perf = holding["perf"].as<float>();
+                String currency = holding["currency"].as<String>();
+                if (currentValue > 0) {
+                    ParqetHoldingDataModel h = ParqetHoldingDataModel();
+                    h.setId(id);
+                    h.setName(name);
+                    h.setPurchasePrice(purchasePrice);
+                    h.setPurchaseValue(purchaseValue);
+                    h.setCurrentPrice(currentPrice);
+                    h.setCurrentValue(currentValue);
+                    h.setShares(shares);
+                    h.setCurrency(currency);
+                    h.setPerf(perf);
+                    holdingArray[count++] = h;
                 }
             }
             // Add total

--- a/firmware/src/widgets/parqetwidget/ParqetWidget.cpp
+++ b/firmware/src/widgets/parqetwidget/ParqetWidget.cpp
@@ -3,6 +3,7 @@
 #include <ArduinoJson.h>
 #include <HTTPClient.h>
 #include <StreamUtils.h>
+#include <TaskFactory.h>
 
 #include <iomanip>
 
@@ -11,12 +12,17 @@ ParqetWidget::ParqetWidget(ScreenManager &manager, ConfigManager &config) : Widg
     m_config.addConfigBool("ParqetWidget", "pqEnabled", &m_enabled, "Enable Widget");
     m_config.addConfigString("ParqetWidget", "pqportfoId", &m_portfolioId, 50, "Portfolio ID (must be set to public!)");
     m_config.addConfigComboBox("ParqetWidget", "pqDefMode", &m_defaultMode, m_modes, PARQET_MODE_COUNT, "Default timeframe (you can change timeframes by medium pressing the middle button)", true);
+    m_config.addConfigComboBox("ParqetWidget", "pqDefPerf", &m_defaultPerfMeasure, m_perfMeasures, PARQET_PERF_COUNT, "Performance measure", true);
+    m_config.addConfigComboBox("ParqetWidget", "pqDefPerfCh", &m_defaultPerfChartMeasure, m_perfChartMeasures, PARQET_PERF_CHART_COUNT, "Chart measure", true);
     m_config.addConfigBool("ParqetWidget", "pqShowClock", &m_showClock, "Show clock on first screen", true);
     m_config.addConfigBool("ParqetWidget", "pqShowTotalScr", &m_showTotalScreen, "Show totals screen", true);
     m_config.addConfigBool("ParqetWidget", "pqShowTotalVal", &m_showTotalValue, "Show total portfolio value", true);
     String optPriceVal[] = {"Show current price", "Show current value"};
     m_config.addConfigComboBox("ParqetWidget", "pqShowValues", &m_showValues, optPriceVal, 2, "Show price or value for stocks", true);
+    m_config.addConfigString("ParqetWidget", "pqProxyUrl", &m_parquetProxyUrl, 75, "ParqetProxy URL", true);
     m_curMode = m_defaultMode;
+    m_curPerfMeasure = m_defaultPerfMeasure;
+    m_curPerfChartMeasure = m_defaultPerfChartMeasure;
 }
 
 void ParqetWidget::setup() {
@@ -73,16 +79,11 @@ void ParqetWidget::draw(bool force) {
 
 void ParqetWidget::update(bool force) {
     if (force || m_stockDelayPrev == 0 || (millis() - m_stockDelayPrev) >= m_stockDelay) {
-        setBusy(true);
         Serial.println("Update ParqetPortfolio");
         if (m_everDrawn && m_showClock) {
             displayClock(0, TFT_BLACK, TFT_WHITE, "Updating", TFT_RED);
         }
         updatePortfolio();
-        updatePortfolioChart();
-        m_holdingsDisplayFrom = 0;
-        m_changed = true;
-        setBusy(false);
         m_stockDelayPrev = millis();
     }
 }
@@ -116,75 +117,63 @@ ParqetDataModel ParqetWidget::getPortfolio() {
 void ParqetWidget::updatePortfolio() {
     PARQET_DEBUG_PRINT_MEM("Begin .updatePortfolio()");
     String portfolioId = String(m_portfolioId.c_str());
-    if (portfolioId.isEmpty()) {
+    if (portfolioId.isEmpty() || m_parquetProxyUrl.empty()) {
         return;
     }
     Serial.printf("Parqet: Update Portfolio %s\n", portfolioId.c_str());
-    String httpRequestAddress = "https://api.parqet.com/v1/portfolios/assemble";
-    String postPayload = "{ \"portfolioIds\": [\"" + portfolioId + "\"], \"holdingIds\": [], \"assetTypes\": [], \"timeframe\": \"" + getTimeframe() + "\"}";
-    PARQET_DEBUG_PRINT("POST Payload: %s", postPayload.c_str());
-    HTTPClient http;
-    const char *keys[] = {"Transfer-Encoding"};
-    http.collectHeaders(keys, 1);
-    http.begin(httpRequestAddress);
-    PARQET_DEBUG_PRINT_MEM("after http.begin()");
-    http.addHeader("Content-Type", "application/json");
+    String httpRequestAddress = String(m_parquetProxyUrl.c_str());
+    httpRequestAddress += "?id=" + portfolioId + "&timeframe=" + getTimeframe() + "&perf=" + m_perfMeasures[m_curPerfMeasure] + "&perfChart=" + m_perfChartMeasures[m_curPerfChartMeasure];
 
-    int httpCode = http.POST(postPayload);
-    PARQET_DEBUG_PRINT("HTTP %d, Size %d", httpCode, http.getSize());
+    auto task = TaskFactory::createHttpGetTask(
+        httpRequestAddress, [this](int httpCode, const String &response) {
+            processResponse(httpCode, response);
+        });
+
+    if (!task) {
+        Serial.println("Failed to create pqValues task");
+        return;
+    }
+
+    bool success = TaskManager::getInstance()->addTask(std::move(task));
+    if (!success) {
+        Serial.println("Failed to add pqValues task");
+        return;
+    }
+}
+
+void ParqetWidget::processResponse(int httpCode, const String &response) {
+    PARQET_DEBUG_PRINT_MEM("start processResponse()");
+    PARQET_DEBUG_PRINT("HTTP %d, Size %d", httpCode, response.length());
 
     // Check for the returning code
     if (httpCode == 200) {
-        Stream &rawStream = http.getStream();
-        PARQET_DEBUG_PRINT_MEM("after getStream()");
-        ChunkDecodingStream decodedStream(rawStream);
-        PARQET_DEBUG_PRINT_MEM("after decodedStream()");
-
-        // Choose the right stream depending on the Transfer-Encoding header
-        // Parqet might send chunked responses
-        Stream &response =
-            http.header("Transfer-Encoding") == "chunked" ? decodedStream : rawStream;
-
         // Parse response
         JsonDocument doc;
-        JsonDocument filter;
-        // Filter the response to save memory
-        filter["holdings"][0]["assetType"] = true;
-        filter["holdings"][0]["currency"] = true;
-        filter["holdings"][0]["asset"] = true;
-        filter["holdings"][0]["sharedAsset"]["name"] = true;
-        filter["holdings"][0]["performance"] = true;
-        filter["holdings"][0]["position"] = true;
-        filter["performance"]["purchaseValueForInterval"] = true;
-        filter["performance"]["portfolioValue"] = true;
 
         PARQET_DEBUG_PRINT_MEM("Parsing portfolio JSON now...");
-        DeserializationError error = deserializeJson(doc, response, DeserializationOption::Filter(filter));
+        DeserializationError error = deserializeJson(doc, response);
         PARQET_DEBUG_PRINT_MEM("after deserializeJson()");
 
         if (!error) {
             JsonArray holdings = doc["holdings"];
             // Initialize a new array (reserver one extra element for totals)
-            ParqetHoldingDataModel *holdingArray = new ParqetHoldingDataModel[holdings.size() + 1];
+            auto *holdingArray = new ParqetHoldingDataModel[holdings.size() + 1];
             PARQET_DEBUG_PRINT_MEM("after new holdingArray");
             int count = 0;
             for (JsonVariant holding : holdings) {
                 String type = holding["assetType"].as<String>();
                 if (type == "security" || type == "crypto") {
                     // stocks or etf/funds
-                    String id = holding["asset"]["identifier"].as<String>();
-                    String name = holding["sharedAsset"]["name"].as<String>();
-                    float purchasePrice = holding["performance"]["priceAtIntervalStart"].as<float>();
-                    float purchaseValue = holding["performance"]["purchaseValueForInterval"].as<float>();
-                    float currentPrice = holding["position"]["currentPrice"].as<float>();
-                    float currentValue = holding["position"]["currentValue"].as<float>();
-                    float shares = holding["position"]["shares"].as<float>();
-                    bool isSold = holding["position"]["isSold"].as<bool>();
+                    String id = holding["id"].as<String>();
+                    String name = holding["name"].as<String>();
+                    float purchasePrice = holding["priceStart"].as<float>();
+                    float purchaseValue = holding["valueStart"].as<float>();
+                    float currentPrice = holding["priceNow"].as<float>();
+                    float currentValue = holding["valueNow"].as<float>();
+                    float shares = holding["shares"].as<float>();
+                    float perf = holding["perf"].as<float>();
                     String currency = holding["currency"].as<String>();
-                    if (isSold || currentValue == 0) {
-                        // Serial.printf("Skipping %s, %s\n", name.c_str(), id.c_str());
-                    } else {
-                        // Serial.printf("Name: %s, id: %s, cur: %s, start: %.2f, now: %.2f, curValue: %.2f\n", name.c_str(), id.c_str(), currency.c_str(), purchasePrice, currentPrice, currentValue);
+                    if (currentValue > 0) {
                         ParqetHoldingDataModel h = ParqetHoldingDataModel();
                         h.setId(id);
                         h.setName(name);
@@ -194,10 +183,9 @@ void ParqetWidget::updatePortfolio() {
                         h.setCurrentValue(currentValue);
                         h.setShares(shares);
                         h.setCurrency(currency);
+                        h.setPerf(perf);
                         holdingArray[count++] = h;
                     }
-                } else {
-                    PARQET_DEBUG_PRINT("Invalid type: %s, id: %s", type.c_str(), holding["_id"].as<String>().c_str());
                 }
             }
             // Add total
@@ -206,10 +194,11 @@ void ParqetWidget::updatePortfolio() {
                 ParqetHoldingDataModel h = ParqetHoldingDataModel();
                 h.setId("total");
                 h.setName("T O T A L");
-                h.setPurchasePrice(perf["purchaseValueForInterval"].as<float>());
-                h.setPurchaseValue(perf["purchaseValueForInterval"].as<float>());
-                h.setCurrentPrice(perf["portfolioValue"].as<float>());
-                h.setCurrentValue(perf["portfolioValue"].as<float>());
+                h.setPurchasePrice(perf["valueStart"].as<float>());
+                h.setPurchaseValue(perf["valueStart"].as<float>());
+                h.setCurrentPrice(perf["valueNow"].as<float>());
+                h.setCurrentValue(perf["valueNow"].as<float>());
+                h.setPerf(perf["perf"].as<float>());
                 h.setShares(1);
                 // AFAIK, the whole portfolio is shown in the same currency.
                 // To avoid another HTTP request, we just use the currency of the first holding
@@ -218,89 +207,17 @@ void ParqetWidget::updatePortfolio() {
                 }
                 holdingArray[count++] = h;
             }
+            PARQET_DEBUG_PRINT_MEM("pre setHoldings()");
             m_portfolio.setHoldings(holdingArray, count);
             PARQET_DEBUG_PRINT_MEM("after setHoldings()");
-        } else {
-            // Handle JSON deserialization error
-            Serial.println("deserializeJson() failed");
-            Serial.println(error.c_str());
-        }
-    } else {
-        // Handle HTTP request error
-        Serial.printf("HTTP request failed, error: %s\n", http.errorToString(httpCode).c_str());
-    }
-
-    http.end();
-    PARQET_DEBUG_PRINT_MEM("Parqet portfolio update complete");
-}
-
-void ParqetWidget::updatePortfolioChart() {
-    PARQET_DEBUG_PRINT_MEM("Begin .updatePortfolioChart()");
-    String portfolioId = String(m_portfolioId.c_str());
-    if (portfolioId.isEmpty()) {
-        return;
-    }
-    String timeframe = getTimeframe();
-    Serial.printf("Parqet: Update Portfolio Chart %s\n", portfolioId.c_str());
-    if (!m_showTotalChart || (timeframe == "today" && m_overrideTotalChartToday == "")) {
-        // We don't need a chart -> clear the existing data
-        m_portfolio.clearChartData();
-        return;
-    }
-    String httpRequestAddress = "https://api.parqet.com/v1/portfolios/assemble/charts?resolution=200";
-
-    if (timeframe == "today") {
-        timeframe = m_overrideTotalChartToday;
-    }
-    String postPayload = "{ \"portfolioIds\": [\"" + portfolioId + "\"], \"holdingIds\": [], \"assetTypes\": [], \"perfChartConfig\": [\"u\"], \"timeframe\": \"" + timeframe + "\"}";
-    PARQET_DEBUG_PRINT("POST Payload: %s", postPayload.c_str());
-    HTTPClient http;
-    const char *keys[] = {"Transfer-Encoding"};
-    http.collectHeaders(keys, 1);
-    http.begin(httpRequestAddress);
-    http.addHeader("Content-Type", "application/json");
-
-    int httpCode = http.POST(postPayload);
-    PARQET_DEBUG_PRINT("HTTP %d, Size %d", httpCode, http.getSize());
-
-    // Check for the returning code
-    if (httpCode == 200) {
-        Stream &rawStream = http.getStream();
-        PARQET_DEBUG_PRINT_MEM("after .getStream()");
-        ChunkDecodingStream decodedStream(rawStream);
-        PARQET_DEBUG_PRINT_MEM("after .decodedStream()");
-
-        // Choose the right stream depending on the Transfer-Encoding header
-        // Parqet might send chunked responses
-        Stream &response =
-            http.header("Transfer-Encoding") == "chunked" ? decodedStream : rawStream;
-
-        // Parse response
-        JsonDocument doc;
-        JsonDocument filter;
-        // Filter the response to save memory
-        filter["charts"][0]["values"]["perfHistory"] = true;
-        PARQET_DEBUG_PRINT_MEM("Parsing chart JSON now...");
-        DeserializationError error = deserializeJson(doc, response, DeserializationOption::Filter(filter));
-        PARQET_DEBUG_PRINT_MEM("after deserializeJson()");
-
-        if (!error) {
-            JsonArray charts = doc["charts"];
-            bool first = true;
-            // Initialize a new array
-            float *chartsArray = new float[charts.size()];
-            int count = 0;
-            for (JsonVariant chart : charts) {
-                if (first) {
-                    // Skip first data point (because the first two will be SOD/EOD of the same date and SOD always has perf==0)
-                    first = false;
-                } else {
-                    float perf = chart["values"]["perfHistory"];
-                    chartsArray[count++] = perf;
-                    // printf("Chart data %d: %.2f\n", count, perf);
-                }
+            JsonArray chart = doc["chart"];
+            float *chartsArray = new float[chart.size()];
+            count = 0;
+            for (JsonVariant val : chart) {
+                chartsArray[count++] = val.as<float>();
             }
             m_portfolio.setChartData(chartsArray, count);
+
         } else {
             // Handle JSON deserialization error
             Serial.println("deserializeJson() failed");
@@ -308,11 +225,12 @@ void ParqetWidget::updatePortfolioChart() {
         }
     } else {
         // Handle HTTP request error
-        Serial.printf("HTTP request failed, error: %s\n", http.errorToString(httpCode).c_str());
+        Serial.printf("HTTP request failed, error: %d\n", httpCode);
     }
 
-    http.end();
-    PARQET_DEBUG_PRINT_MEM("Parqet chart update complete");
+    PARQET_DEBUG_PRINT_MEM("Parqet portfolio update complete");
+    m_holdingsDisplayFrom = 0;
+    m_changed = true;
 }
 
 void ParqetWidget::clearScreen(int8_t displayIndex, int32_t background) {
@@ -433,9 +351,9 @@ void ParqetWidget::displayStock(int8_t displayIndex, ParqetHoldingDataModel &sto
     }
 
     uint32_t stockColor = TFT_DARKGREY;
-    if (stock.getPercentChange() < 0) {
+    if (stock.getPerf() < 0) {
         stockColor = TFT_RED;
-    } else if (stock.getPercentChange() > 0) {
+    } else if (stock.getPerf() > 0) {
         stockColor = TFT_DARKGREEN;
     }
 
@@ -443,7 +361,7 @@ void ParqetWidget::displayStock(int8_t displayIndex, ParqetHoldingDataModel &sto
     m_manager.fillRect(0, 80, ScreenWidth, 5, stockColor);
     m_manager.fillRect(0, 176, ScreenWidth, 5, stockColor);
     m_manager.drawArc(120, 120, 120, 115, 0, 360, stockColor, backgroundColor);
-    m_manager.drawString(stock.getPercentChange(2) + "%", ScreenCenterX, 205, 22, Align::MiddleCenter);
+    m_manager.drawString(stock.getPerf(2) + "%", ScreenCenterX, 205, 22, Align::MiddleCenter);
 }
 
 String ParqetWidget::getName() {

--- a/firmware/src/widgets/parqetwidget/ParqetWidget.cpp
+++ b/firmware/src/widgets/parqetwidget/ParqetWidget.cpp
@@ -107,7 +107,27 @@ void ParqetWidget::buttonPressed(uint8_t buttonId, ButtonState state) {
 }
 
 String ParqetWidget::getTimeframe() {
-    return m_modes[m_curMode];
+    if (m_curMode < PARQET_MODE_COUNT) {
+        return m_modes[m_curMode];
+    } else {
+        return m_modes[0];
+    }
+}
+
+String ParqetWidget::getPerfMeasure() {
+    if (m_curPerfMeasure < PARQET_PERF_COUNT) {
+        return m_perfMeasures[m_curPerfMeasure];
+    } else {
+        return m_perfMeasures[0];
+    }
+}
+
+String ParqetWidget::getPerfChartMeasure() {
+    if (m_curPerfChartMeasure < PARQET_PERF_CHART_COUNT) {
+        return m_perfChartMeasures[m_curPerfChartMeasure];
+    } else {
+        return m_perfChartMeasures[0];
+    }
 }
 
 ParqetDataModel ParqetWidget::getPortfolio() {
@@ -121,7 +141,7 @@ void ParqetWidget::updatePortfolio() {
     }
     Serial.printf("Parqet: Update Portfolio %s\n", m_portfolioId.c_str());
     String httpRequestAddress = String(m_parquetProxyUrl.c_str());
-    httpRequestAddress += "?id=" + String(m_portfolioId.c_str()) + "&timeframe=" + getTimeframe() + "&perf=" + m_perfMeasures[m_curPerfMeasure] + "&perfChart=" + m_perfChartMeasures[m_curPerfChartMeasure];
+    httpRequestAddress += "?id=" + String(m_portfolioId.c_str()) + "&timeframe=" + getTimeframe() + "&perf=" + getPerfMeasure() + "&perfChart=" + getPerfChartMeasure();
 
     auto task = TaskFactory::createHttpGetTask(
         httpRequestAddress, [this](int httpCode, const String &response) {

--- a/firmware/src/widgets/parqetwidget/ParqetWidget.h
+++ b/firmware/src/widgets/parqetwidget/ParqetWidget.h
@@ -58,8 +58,6 @@ private:
     String getPerfChartMeasure();
     void updatePortfolio();
     void processResponse(int httpCode, const String &response);
-    void updatePortfolioChart();
-    void processResponseChart(int httpCode, const String &response);
     void displayStock(int8_t displayIndex, ParqetHoldingDataModel &stock, uint32_t backgroundColor, uint32_t textColor);
     ParqetDataModel getPortfolio();
     void clearScreen(int8_t displayIndex, int32_t background);

--- a/firmware/src/widgets/parqetwidget/ParqetWidget.h
+++ b/firmware/src/widgets/parqetwidget/ParqetWidget.h
@@ -32,7 +32,7 @@
 
 #define PARQET_MODE_COUNT 10
 #define PARQET_PERF_COUNT 6
-#define PARQET_PERF_CHART_COUNT 5
+#define PARQET_PERF_CHART_COUNT 4
 #define PARQET_MAX_STOCKNAME_LINES 3
 
 class ParqetWidget : public Widget {
@@ -74,7 +74,7 @@ private:
     int m_defaultPerfMeasure = 0;
     int m_curPerfMeasure = 0;
 
-    String m_perfChartMeasures[PARQET_PERF_CHART_COUNT] = {"perfHistory", "perfHistoryUnrealized", "ttwror", "drawdown", "none"};
+    String m_perfChartMeasures[PARQET_PERF_CHART_COUNT] = {"perfHistory", "perfHistoryUnrealized", "ttwror", "drawdown"};
     int m_defaultPerfChartMeasure = 0;
     int m_curPerfChartMeasure = 0;
 

--- a/firmware/src/widgets/parqetwidget/ParqetWidget.h
+++ b/firmware/src/widgets/parqetwidget/ParqetWidget.h
@@ -96,7 +96,7 @@ private:
     int m_showValues = 0; // Show current price (0) or value in portfolio (1)
 
     std::string m_portfolioId = PARQET_PORTFOLIO_ID;
-    std::string m_parquetProxyUrl = PARQET_PROXY_URL;
+    std::string m_proxyUrl = PARQET_PROXY_URL;
     ParqetDataModel m_portfolio;
     int m_holdingsDisplayFrom = 0;
     boolean m_changed = false;

--- a/firmware/src/widgets/parqetwidget/ParqetWidget.h
+++ b/firmware/src/widgets/parqetwidget/ParqetWidget.h
@@ -31,6 +31,8 @@
 #endif
 
 #define PARQET_MODE_COUNT 10
+#define PARQET_PERF_COUNT 6
+#define PARQET_PERF_CHART_COUNT 5
 #define PARQET_MAX_STOCKNAME_LINES 3
 
 class ParqetWidget : public Widget {
@@ -45,7 +47,9 @@ public:
 private:
     String getTimeframe();
     void updatePortfolio();
+    void processResponse(int httpCode, const String &response);
     void updatePortfolioChart();
+    void processResponseChart(int httpCode, const String &response);
     void displayStock(int8_t displayIndex, ParqetHoldingDataModel &stock, uint32_t backgroundColor, uint32_t textColor);
     ParqetDataModel getPortfolio();
     void clearScreen(int8_t displayIndex, int32_t background);
@@ -66,6 +70,14 @@ private:
     int m_defaultMode = 0;
     int m_curMode = 0;
 
+    String m_perfMeasures[PARQET_PERF_COUNT] = {"totalReturnGross", "totalReturnNet", "returnGross", "returnNet", "ttwror", "izf"};
+    int m_defaultPerfMeasure = 0;
+    int m_curPerfMeasure = 0;
+
+    String m_perfChartMeasures[PARQET_PERF_CHART_COUNT] = {"perfHistory", "perfHistoryUnrealized", "ttwror", "drawdown", "none"};
+    int m_defaultPerfChartMeasure = 0;
+    int m_curPerfChartMeasure = 0;
+
     boolean m_showClock = true; // Show clock on first screen
     boolean m_showTotalScreen = true; // Show a total portfolio screen
     boolean m_showTotalValue = false; // Show your total portfolio value
@@ -78,6 +90,7 @@ private:
 #else
     std::string m_portfolioId = "";
 #endif
+    std::string m_parquetProxyUrl = "https://parqet-proxy.ce-data.net/proxy";
     ParqetDataModel m_portfolio;
     int m_holdingsDisplayFrom = 0;
     boolean m_changed = false;

--- a/firmware/src/widgets/parqetwidget/ParqetWidget.h
+++ b/firmware/src/widgets/parqetwidget/ParqetWidget.h
@@ -54,6 +54,8 @@ public:
 
 private:
     String getTimeframe();
+    String getPerfMeasure();
+    String getPerfChartMeasure();
     void updatePortfolio();
     void processResponse(int httpCode, const String &response);
     void updatePortfolioChart();

--- a/firmware/src/widgets/parqetwidget/ParqetWidget.h
+++ b/firmware/src/widgets/parqetwidget/ParqetWidget.h
@@ -35,6 +35,14 @@
 #define PARQET_PERF_CHART_COUNT 4
 #define PARQET_MAX_STOCKNAME_LINES 3
 
+#ifndef PARQET_PORTFOLIO_ID
+    #define PARQET_PORTFOLIO_ID ""
+#endif
+
+#ifndef PARQET_PROXY_URL
+    #define PARQET_PROXY_URL "https://parqet-proxy.ce-data.net/proxy"
+#endif
+
 class ParqetWidget : public Widget {
 public:
     ParqetWidget(ScreenManager &manager, ConfigManager &config);
@@ -85,12 +93,8 @@ private:
     String m_overrideTotalChartToday = "1w"; // Show this chart for "today" to have a chart there as well, set to empty string to disable
     int m_showValues = 0; // Show current price (0) or value in portfolio (1)
 
-#ifdef PARQET_PORTFOLIO_ID
     std::string m_portfolioId = PARQET_PORTFOLIO_ID;
-#else
-    std::string m_portfolioId = "";
-#endif
-    std::string m_parquetProxyUrl = "https://parqet-proxy.ce-data.net/proxy";
+    std::string m_parquetProxyUrl = PARQET_PROXY_URL;
     ParqetDataModel m_portfolio;
     int m_holdingsDisplayFrom = 0;
     boolean m_changed = false;


### PR DESCRIPTION
This will drastically reduce the memory footprint on the ESP (like 100kB -> 3kb) and increase the parsing speed.

This also allows us to use `TaskFactory::createHttpGetTask` to fetch the Parqet data in background.

I'm hosting the proxy on my server at the moment, but everybody can host their own proxy if they want (e.g. for privacy reasons).

The proxy source code (in Python) with Docker support can be found here: 
https://github.com/flattermann/info-orbs-parqet-proxy/

This PR supersedes #229.