### PR TITLE
Set NTP update interval to every 15 minutes.  Also check for update r…

### DIFF
--- a/firmware/src/core/globaltime/GlobalTime.h
+++ b/firmware/src/core/globaltime/GlobalTime.h
@@ -93,8 +93,8 @@ private:
     NTPClient *m_timeClient{nullptr};
 
     unsigned long m_updateInterval = 900000; // Update every 15 min
-    int m_lowYearTest = 2020;
-    int m_highYearTest = 2030;
+    const int m_lowYearTest = 2025;
+    const int m_highYearTest = 2035;
     unsigned long m_oneSecond = 1000;
     unsigned long m_updateTimer = 0;
 

--- a/firmware/src/core/globaltime/GlobalTime.h
+++ b/firmware/src/core/globaltime/GlobalTime.h
@@ -92,6 +92,9 @@ private:
     WiFiUDP m_udp;
     NTPClient *m_timeClient{nullptr};
 
+    unsigned long m_updateInterval = 900000; // Update every 15 min
+    int m_lowYearTest = 2020;
+    int m_highYearTest = 2030;
     unsigned long m_oneSecond = 1000;
     unsigned long m_updateTimer = 0;
 


### PR DESCRIPTION
Set NTP update interval to every 15 minutes.  Also check for update returned unixEpoch year and ensure its within a defined range and it its not retry every 3 seconds until its a valid return.  should address issues #225, #226, #227