### PR TITLE
Use i18n for weekdays, month names and date format

### DIFF
--- a/firmware/config/config.h.template
+++ b/firmware/config/config.h.template
@@ -7,7 +7,7 @@
 #define TIMEZONE_API_LOCATION "America/Vancouver" // Use timezone from this list: https://timezonedb.com/time-zones
 #define ORB_ROTATION 0                            // 0 = Normal, 1 = 90 degrees CW, 2 = 180 degrees, 3 = 270 degrees CW
 #define WIDGET_CYCLE_DELAY 0                      // Automatically cycle widgets every X seconds, set to 0 to disable
-#define LOCALE EN                                 // Language selection for Month and Weekday - possible values are EN, DE, FR
+#define LANGUAGE LANG_EN                          // Language selection - possible values are LANG_EN, LANG_DE, LANG_FR
 
 // WIDGETS
 #define INCLUDE_WEATHER       // include WeatherWidget

--- a/firmware/src/core/globaltime/GlobalTime.cpp
+++ b/firmware/src/core/globaltime/GlobalTime.cpp
@@ -1,6 +1,7 @@
 #include "GlobalTime.h"
 
 #include "ConfigManager.h"
+#include "Translations.h"
 #include "config_helper.h"
 #include <ArduinoJson.h>
 #include <ArduinoLog.h>
@@ -57,9 +58,9 @@ void GlobalTime::updateTime(bool force) {
 
         m_day = day(m_unixEpoch);
         m_month = month(m_unixEpoch);
-        m_monthName = LOC_MONTH[m_month - 1];
+        m_monthName = i18n(t_months, m_month - 1);
         m_year = year(m_unixEpoch);
-        m_weekday = LOC_WEEKDAY[(weekday(m_unixEpoch)) -1];
+        m_weekday = i18n(t_weekdays, weekday(m_unixEpoch) - 1);
         m_time = String(m_hour) + ":" + (m_minute < 10 ? "0" + String(m_minute) : String(m_minute));
     }
 }
@@ -131,7 +132,7 @@ String GlobalTime::getWeekday() {
 
 String GlobalTime::getDayAndMonth() {
 #ifdef WEATHER_UNITS_METRIC
-    String retVal = LOC_FORMAT_DAYMONTH;
+    String retVal = i18n(t_dayMonthFormat);
     retVal.replace("%d", String(m_day));
     retVal.replace("%B", m_monthName);
     return retVal;

--- a/firmware/src/core/globaltime/GlobalTime.h
+++ b/firmware/src/core/globaltime/GlobalTime.h
@@ -6,28 +6,6 @@
 #include <NTPClient.h>
 #include <TimeLib.h>
 
-// Define locales
-#define EN 0
-#define DE 1
-#define FR 2
-
-#if LOCALE == DE // German
-const char LOC_MONTH[12][10] = {"Januar", "Februar", "Maerz", "April", "Mai", "Juni", "Juli", "August", "September", "Oktober", "November", "Dezember"}; // Define german for month
-const char LOC_WEEKDAY[7][11] = {"Sonntag", "Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag"}; // Define german for weekday
-const String LOC_FORMAT_DAYMONTH = "%d. %B"; // in strftime format
-const String LOC_LANG = "de";
-#elif LOCALE == FR // French
-const char LOC_MONTH[12][10] = {"Janvier", "Février", "Mars", "Avril", "Mai", "Juin", "Juillet", "Août", "Septembre", "Octobre", "Novembre", "Décembre"}; // Define french for month
-const char LOC_WEEKDAY[7][11] = {"Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi", "Dimanche"}; // Define french for weekday
-const String LOC_FORMAT_DAYMONTH = "%d %B"; // in strftime format
-const String LOC_LANG = "fr";
-#else // English
-const char LOC_MONTH[12][10] = {"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"}; // Define english for month
-const char LOC_WEEKDAY[7][11] = {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"}; // Define english for weekday
-const String LOC_FORMAT_DAYMONTH = "%d %B"; // in strftime format, this will be overriden if WEATHER_UNITS_METRIC is not set
-const String LOC_LANG = "en";
-#endif
-
 enum ClockFormat {
     CLOCK_FORMAT_24_HOUR = 0,
     CLOCK_FORMAT_12_HOUR = 1,

--- a/firmware/src/core/i18n/I18n.cpp
+++ b/firmware/src/core/i18n/I18n.cpp
@@ -1,7 +1,7 @@
 #include "I18n.h"
 
 String I18n::s_allLanguages[] = ALL_LANGUAGES;
-int I18n::s_languageId = DEFAULT_LANGUAGE;
+int I18n::s_languageId = LANGUAGE;
 
 void I18n::setLanguageId(const int langId) {
     if (langId >= 0 && langId < LANG_NUM) {
@@ -9,6 +9,10 @@ void I18n::setLanguageId(const int langId) {
     } else {
         s_languageId = DEFAULT_LANGUAGE;
     }
+}
+
+String I18n::getLanguageString() {
+    return getLanguageString(s_languageId);
 }
 
 String I18n::getLanguageString(const int langId) {

--- a/firmware/src/core/i18n/I18n.h
+++ b/firmware/src/core/i18n/I18n.h
@@ -15,6 +15,10 @@ enum Language {
 
 #define DEFAULT_LANGUAGE LANG_EN
 
+#ifndef LANGUAGE
+    #define LANGUAGE DEFAULT_LANGUAGE
+#endif
+
 // Define a custom type for translation arrays
 using Translation = const char *const[LANG_NUM];
 // Define a template for translation arrays with a fixed number of columns (LANG_NUM)
@@ -25,6 +29,7 @@ class I18n {
 public:
     static void setLanguageId(int langId);
     static String getLanguageString(int langId);
+    static String getLanguageString();
     static String *getAllLanguages();
 
     static const char *get(Translation &translations) {

--- a/firmware/src/core/i18n/Translations.cpp
+++ b/firmware/src/core/i18n/Translations.cpp
@@ -179,3 +179,109 @@ constexpr TranslationMulti<2> t_screenModes = {
     {
         "Dark", // EN
     }};
+
+constexpr TranslationMulti<12> t_months = {
+    {
+        "January", // EN
+        "Januar", // DE
+        "Janvier", // FR
+    },
+    {
+        "February", // EN
+        "Februar", // DE
+        "Février", // FR
+    },
+    {
+        "March", // EN
+        "März", // DE
+        "Mars", // FR
+    },
+    {
+        "April", // EN
+        "April", // DE
+        "Avril", // FR
+    },
+    {
+        "May", // EN
+        "Mai", // DE
+        "Mai", // FR
+    },
+    {
+        "June", // EN
+        "Juni", // DE
+        "Juin", // FR
+    },
+    {
+        "July", // EN
+        "Juli", // DE
+        "Juillet", // FR
+    },
+    {
+        "August", // EN
+        "August", // DE
+        "Août", // FR
+    },
+    {
+        "September", // EN
+        "September", // DE
+        "Septembre", // FR
+    },
+    {
+        "October", // EN
+        "Oktober", // DE
+        "Octobre", // FR
+    },
+    {
+        "November", // EN
+        "November", // DE
+        "Novembre", // FR
+    },
+    {
+        "December", // EN
+        "Dezember", // DE
+        "Décembre", // FR
+    }};
+
+constexpr TranslationMulti<7> t_weekdays = {
+    {
+        "Sunday", // EN
+        "Sonntag", // DE
+        "Dimanche", // FR
+    },
+    {
+        "Monday", // EN
+        "Montag", // DE
+        "Lundi", // FR
+    },
+    {
+        "Tuesday", // EN
+        "Dienstag", // DE
+        "Mardi", // FR
+    },
+    {
+        "Wednesday", // EN
+        "Mittwoch", // DE
+        "Mercredi", // FR
+    },
+    {
+        "Thursday", // EN
+        "Donnerstag", // DE
+        "Jeudi", // FR
+    },
+    {
+        "Friday", // EN
+        "Freitag", // DE
+        "Vendredi", // FR
+    },
+    {
+        "Saturday", // EN
+        "Samstag", // DE
+        "Samedi", // FR
+    }};
+
+constexpr Translation t_dayMonthFormat = {
+    // in strftime format
+    "%d %B", // EN
+    "%d. %B", // DE
+    "%d %B", // FR
+};

--- a/firmware/src/core/i18n/Translations.h
+++ b/firmware/src/core/i18n/Translations.h
@@ -34,5 +34,8 @@ extern Translation t_temperatureUnit;
 extern TranslationMulti<2> t_temperatureUnits;
 extern Translation t_screenMode;
 extern TranslationMulti<2> t_screenModes;
+extern TranslationMulti<12> t_months;
+extern TranslationMulti<7> t_weekdays;
+extern Translation t_dayMonthFormat;
 
 #endif // TRANSLATIONS_H

--- a/firmware/src/widgets/weatherwidget/WeatherWidget.cpp
+++ b/firmware/src/widgets/weatherwidget/WeatherWidget.cpp
@@ -91,9 +91,14 @@ void WeatherWidget::update(bool force) {
 
 bool WeatherWidget::getWeatherData() {
     String weatherUnits = m_weatherUnits == 0 ? "metric" : "us";
+    String lang = I18n::getLanguageString();
+    if (lang != "en" && lang != "de" && lang != "fr") {
+        // Language is not supported on visualcrossing -> use english
+        lang = "en";
+    }
     String httpRequestAddress = "https://weather.visualcrossing.com/VisualCrossingWebServices/rest/services/timeline/" +
                                 String(m_weatherLocation.c_str()) + "/next3days?key=" + weatherApiKey + "&unitGroup=" + weatherUnits +
-                                "&include=days,current&iconSet=icons1&lang=" + LOC_LANG;
+                                "&include=days,current&iconSet=icons1&lang=" + lang;
 
     auto task = TaskFactory::createHttpGetTask(
         httpRequestAddress, [this](int httpCode, const String &response) { processResponse(httpCode, response); }, [this](int httpCode, String &response) { preProcessResponse(httpCode, response); });
@@ -329,7 +334,7 @@ void WeatherWidget::threeDayWeather(int displayIndex) {
         drawWeatherIcon(displayIndex, model.getDayIcon(i), x - 30, 40, 4);
         m_manager.drawCentreString(temps[i], x, 122, temperatureFontSize);
 
-        String shortDayName = LOC_WEEKDAY[weekday(m_time->getUnixEpoch() + (86400 * (i + 1))) - 1];
+        String shortDayName = i18n(t_weekdays, weekday(m_time->getUnixEpoch() + (86400 * (i + 1))) - 1);
         shortDayName.remove(3);
         m_manager.drawString(shortDayName, x, 154, fontSize, Align::MiddleCenter);
     }


### PR DESCRIPTION
Replaced static language definitions with dynamic translations for months, weekdays, and date formatting. Implemented centralized language handling for more flexible internationalization and removed obsolete `LOC_*` constants. Updated weather and time modules to use the new translation system.