### PR TITLE
Integrate NTPClient library to fix upstream bug

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -28,4 +28,4 @@ FILEIO_REPORTER: false
 # Uncomment if you want MegaLinter to detect errors but not block CI to pass
 # DISABLE_ERRORS: true
 
-CPP_CLANG_FORMAT_FILTER_REGEX_EXCLUDE: firmware/lib/OpenFontRender/.*
+CPP_CLANG_FORMAT_FILTER_REGEX_EXCLUDE: firmware/lib/.*

--- a/firmware/lib/NTPClient/.clang-format
+++ b/firmware/lib/NTPClient/.clang-format
@@ -1,0 +1,4 @@
+{
+  DisableFormat: true,
+  SortIncludes: Never
+}

--- a/firmware/lib/NTPClient/.codespellrc
+++ b/firmware/lib/NTPClient/.codespellrc
@@ -1,0 +1,7 @@
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
+ignore-words-list = ,
+check-filenames =
+check-hidden =
+skip = ./.git

--- a/firmware/lib/NTPClient/CHANGELOG
+++ b/firmware/lib/NTPClient/CHANGELOG
@@ -1,0 +1,15 @@
+NTPClient 3.1.0 - 2016.05.31
+
+* Added functions for changing the timeOffset and updateInterval later. Thanks @SirUli
+
+NTPClient 3.0.0 - 2016.04.19
+
+* Constructors now require UDP instance argument, to add support for non-ESP8266 boards
+* Added optional begin API to override default local port
+* Added end API to close UDP socket
+* Changed return type of update and forceUpdate APIs to bool, and return success or failure
+* Change return type of getDay, getHours, getMinutes, and getSeconds to int
+
+Older
+
+* Changes not recorded

--- a/firmware/lib/NTPClient/NTPClient.cpp
+++ b/firmware/lib/NTPClient/NTPClient.cpp
@@ -1,0 +1,212 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2015 by Fabrice Weinberg
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "NTPClient.h"
+
+NTPClient::NTPClient(UDP& udp) {
+  this->_udp            = &udp;
+}
+
+NTPClient::NTPClient(UDP& udp, long timeOffset) {
+  this->_udp            = &udp;
+  this->_timeOffset     = timeOffset;
+}
+
+NTPClient::NTPClient(UDP& udp, const char* poolServerName) {
+  this->_udp            = &udp;
+  this->_poolServerName = poolServerName;
+}
+
+NTPClient::NTPClient(UDP& udp, IPAddress poolServerIP) {
+  this->_udp            = &udp;
+  this->_poolServerIP   = poolServerIP;
+  this->_poolServerName = NULL;
+}
+
+NTPClient::NTPClient(UDP& udp, const char* poolServerName, long timeOffset) {
+  this->_udp            = &udp;
+  this->_timeOffset     = timeOffset;
+  this->_poolServerName = poolServerName;
+}
+
+NTPClient::NTPClient(UDP& udp, IPAddress poolServerIP, long timeOffset){
+  this->_udp            = &udp;
+  this->_timeOffset     = timeOffset;
+  this->_poolServerIP   = poolServerIP;
+  this->_poolServerName = NULL;
+}
+
+NTPClient::NTPClient(UDP& udp, const char* poolServerName, long timeOffset, unsigned long updateInterval) {
+  this->_udp            = &udp;
+  this->_timeOffset     = timeOffset;
+  this->_poolServerName = poolServerName;
+  this->_updateInterval = updateInterval;
+}
+
+NTPClient::NTPClient(UDP& udp, IPAddress poolServerIP, long timeOffset, unsigned long updateInterval) {
+  this->_udp            = &udp;
+  this->_timeOffset     = timeOffset;
+  this->_poolServerIP   = poolServerIP;
+  this->_poolServerName = NULL;
+  this->_updateInterval = updateInterval;
+}
+
+void NTPClient::begin() {
+  this->begin(NTP_DEFAULT_LOCAL_PORT);
+}
+
+void NTPClient::begin(unsigned int port) {
+  this->_port = port;
+
+  this->_udp->begin(this->_port);
+
+  this->_udpSetup = true;
+}
+
+bool NTPClient::forceUpdate() {
+  #ifdef DEBUG_NTPClient
+    Serial.println("Update from NTP Server");
+  #endif
+
+  // flush any existing packets
+  while(this->_udp->parsePacket() != 0)
+    this->_udp->flush();
+
+  this->sendNTPPacket();
+
+  // Wait till data is there or timeout...
+  byte timeout = 0;
+  int cb = 0;
+  do {
+    delay ( 10 );
+    cb = this->_udp->parsePacket();
+    if (timeout > 100) return false; // timeout after 1000 ms
+    timeout++;
+  } while (cb == 0);
+
+  this->_lastUpdate = millis() - (10 * (timeout + 1)); // Account for delay in reading the time
+
+  this->_udp->read(this->_packetBuffer, NTP_PACKET_SIZE);
+
+  unsigned long highWord = word(this->_packetBuffer[40], this->_packetBuffer[41]);
+  unsigned long lowWord = word(this->_packetBuffer[42], this->_packetBuffer[43]);
+  // combine the four bytes (two words) into a long integer
+  // this is NTP time (seconds since Jan 1 1900):
+  unsigned long secsSince1900 = highWord << 16 | lowWord;
+
+  this->_currentEpoc = secsSince1900 - SEVENZYYEARS;
+
+  return true;  // return true after successful update
+}
+
+bool NTPClient::update() {
+  if ((millis() - this->_lastUpdate >= this->_updateInterval)     // Update after _updateInterval
+    || this->_lastUpdate == 0) {                                // Update if there was no update yet.
+    if (!this->_udpSetup || this->_port != NTP_DEFAULT_LOCAL_PORT) this->begin(this->_port); // setup the UDP client if needed
+    return this->forceUpdate();
+  }
+  return false;   // return false if update does not occur
+}
+
+bool NTPClient::isTimeSet() const {
+  return (this->_lastUpdate != 0); // returns true if the time has been set, else false
+}
+
+unsigned long NTPClient::getEpochTime() const {
+  return this->_timeOffset + // User offset
+         this->_currentEpoc + // Epoch returned by the NTP server
+         ((millis() - this->_lastUpdate) / 1000); // Time since last update
+}
+
+int NTPClient::getDay() const {
+  return (((this->getEpochTime()  / 86400L) + 4 ) % 7); //0 is Sunday
+}
+int NTPClient::getHours() const {
+  return ((this->getEpochTime()  % 86400L) / 3600);
+}
+int NTPClient::getMinutes() const {
+  return ((this->getEpochTime() % 3600) / 60);
+}
+int NTPClient::getSeconds() const {
+  return (this->getEpochTime() % 60);
+}
+
+String NTPClient::getFormattedTime() const {
+  unsigned long rawTime = this->getEpochTime();
+  unsigned long hours = (rawTime % 86400L) / 3600;
+  String hoursStr = hours < 10 ? "0" + String(hours) : String(hours);
+
+  unsigned long minutes = (rawTime % 3600) / 60;
+  String minuteStr = minutes < 10 ? "0" + String(minutes) : String(minutes);
+
+  unsigned long seconds = rawTime % 60;
+  String secondStr = seconds < 10 ? "0" + String(seconds) : String(seconds);
+
+  return hoursStr + ":" + minuteStr + ":" + secondStr;
+}
+
+void NTPClient::end() {
+  this->_udp->stop();
+
+  this->_udpSetup = false;
+}
+
+void NTPClient::setTimeOffset(int timeOffset) {
+  this->_timeOffset     = timeOffset;
+}
+
+void NTPClient::setUpdateInterval(unsigned long updateInterval) {
+  this->_updateInterval = updateInterval;
+}
+
+void NTPClient::setPoolServerName(const char* poolServerName) {
+    this->_poolServerName = poolServerName;
+}
+
+void NTPClient::sendNTPPacket() {
+  // set all bytes in the buffer to 0
+  memset(this->_packetBuffer, 0, NTP_PACKET_SIZE);
+  // Initialize values needed to form NTP request
+  this->_packetBuffer[0] = 0b11100011;   // LI, Version, Mode
+  this->_packetBuffer[1] = 0;     // Stratum, or type of clock
+  this->_packetBuffer[2] = 6;     // Polling Interval
+  this->_packetBuffer[3] = 0xEC;  // Peer Clock Precision
+  // 8 bytes of zero for Root Delay & Root Dispersion
+  this->_packetBuffer[12]  = 49;
+  this->_packetBuffer[13]  = 0x4E;
+  this->_packetBuffer[14]  = 49;
+  this->_packetBuffer[15]  = 52;
+
+  // all NTP fields have been given values, now
+  // you can send a packet requesting a timestamp:
+  if  (this->_poolServerName) {
+    this->_udp->beginPacket(this->_poolServerName, 123);
+  } else {
+    this->_udp->beginPacket(this->_poolServerIP, 123);
+  }
+  this->_udp->write(this->_packetBuffer, NTP_PACKET_SIZE);
+  this->_udp->endPacket();
+}
+
+void NTPClient::setRandomPort(unsigned int minValue, unsigned int maxValue) {
+  randomSeed(analogRead(0));
+  this->_port = random(minValue, maxValue);
+}

--- a/firmware/lib/NTPClient/NTPClient.h
+++ b/firmware/lib/NTPClient/NTPClient.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include "Arduino.h"
+
+#include <Udp.h>
+
+#define SEVENZYYEARS 2208988800UL
+#define NTP_PACKET_SIZE 48
+#define NTP_DEFAULT_LOCAL_PORT 1337
+
+class NTPClient {
+  private:
+    UDP*          _udp;
+    bool          _udpSetup       = false;
+
+    const char*   _poolServerName = "pool.ntp.org"; // Default time server
+    IPAddress     _poolServerIP;
+    unsigned int  _port           = NTP_DEFAULT_LOCAL_PORT;
+    long          _timeOffset     = 0;
+
+    unsigned long _updateInterval = 60000;  // In ms
+
+    unsigned long _currentEpoc    = 0;      // In s
+    unsigned long _lastUpdate     = 0;      // In ms
+
+    byte          _packetBuffer[NTP_PACKET_SIZE];
+
+    void          sendNTPPacket();
+
+  public:
+    NTPClient(UDP& udp);
+    NTPClient(UDP& udp, long timeOffset);
+    NTPClient(UDP& udp, const char* poolServerName);
+    NTPClient(UDP& udp, const char* poolServerName, long timeOffset);
+    NTPClient(UDP& udp, const char* poolServerName, long timeOffset, unsigned long updateInterval);
+    NTPClient(UDP& udp, IPAddress poolServerIP);
+    NTPClient(UDP& udp, IPAddress poolServerIP, long timeOffset);
+    NTPClient(UDP& udp, IPAddress poolServerIP, long timeOffset, unsigned long updateInterval);
+
+    /**
+     * Set time server name
+     *
+     * @param poolServerName
+     */
+    void setPoolServerName(const char* poolServerName);
+
+     /**
+     * Set random local port
+     */
+    void setRandomPort(unsigned int minValue = 49152, unsigned int maxValue = 65535);
+
+    /**
+     * Starts the underlying UDP client with the default local port
+     */
+    void begin();
+
+    /**
+     * Starts the underlying UDP client with the specified local port
+     */
+    void begin(unsigned int port);
+
+    /**
+     * This should be called in the main loop of your application. By default an update from the NTP Server is only
+     * made every 60 seconds. This can be configured in the NTPClient constructor.
+     *
+     * @return true on success, false on failure
+     */
+    bool update();
+
+    /**
+     * This will force the update from the NTP Server.
+     *
+     * @return true on success, false on failure
+     */
+    bool forceUpdate();
+
+    /**
+     * This allows to check if the NTPClient successfully received a NTP packet and set the time.
+     *
+     * @return true if time has been set, else false
+     */
+    bool isTimeSet() const;
+
+    int getDay() const;
+    int getHours() const;
+    int getMinutes() const;
+    int getSeconds() const;
+
+    /**
+     * Changes the time offset. Useful for changing timezones dynamically
+     */
+    void setTimeOffset(int timeOffset);
+
+    /**
+     * Set the update interval to another frequency. E.g. useful when the
+     * timeOffset should not be set in the constructor
+     */
+    void setUpdateInterval(unsigned long updateInterval);
+
+    /**
+     * @return time formatted like `hh:mm:ss`
+     */
+    String getFormattedTime() const;
+
+    /**
+     * @return time in seconds since Jan. 1, 1970
+     */
+    unsigned long getEpochTime() const;
+
+    /**
+     * Stops the underlying UDP client
+     */
+    void end();
+};

--- a/firmware/lib/NTPClient/README.md
+++ b/firmware/lib/NTPClient/README.md
@@ -1,0 +1,52 @@
+# NTPClient
+
+[![Check Arduino status](https://github.com/arduino-libraries/NTPClient/actions/workflows/check-arduino.yml/badge.svg)](https://github.com/arduino-libraries/NTPClient/actions/workflows/check-arduino.yml)
+[![Compile Examples status](https://github.com/arduino-libraries/NTPClient/actions/workflows/compile-examples.yml/badge.svg)](https://github.com/arduino-libraries/NTPClient/actions/workflows/compile-examples.yml)
+[![Spell Check status](https://github.com/arduino-libraries/NTPClient/actions/workflows/spell-check.yml/badge.svg)](https://github.com/arduino-libraries/NTPClient/actions/workflows/spell-check.yml)
+
+Connect to an NTP server, here is how:
+
+```cpp
+#include <NTPClient.h>
+// change next line to use with another board/shield
+#include <ESP8266WiFi.h>
+//#include <WiFi.h> // for WiFi shield
+//#include <WiFi101.h> // for WiFi 101 shield or MKR1000
+#include <WiFiUdp.h>
+
+const char *ssid     = "<SSID>";
+const char *password = "<PASSWORD>";
+
+WiFiUDP ntpUDP;
+
+// By default 'pool.ntp.org' is used with 60 seconds update interval and
+// no offset
+NTPClient timeClient(ntpUDP);
+
+// You can specify the time server pool and the offset, (in seconds)
+// additionally you can specify the update interval (in milliseconds).
+// NTPClient timeClient(ntpUDP, "europe.pool.ntp.org", 3600, 60000);
+
+void setup(){
+  Serial.begin(115200);
+  WiFi.begin(ssid, password);
+
+  while ( WiFi.status() != WL_CONNECTED ) {
+    delay ( 500 );
+    Serial.print ( "." );
+  }
+
+  timeClient.begin();
+}
+
+void loop() {
+  timeClient.update();
+
+  Serial.println(timeClient.getFormattedTime());
+
+  delay(1000);
+}
+```
+
+## Function documentation
+`getEpochTime` returns the Unix epoch, which are the seconds elapsed since 00:00:00 UTC on 1 January 1970 (leap seconds are ignored, every day is treated as having 86400 seconds). **Attention**: If you have set a time offset this time offset will be added to your epoch timestamp.

--- a/firmware/lib/NTPClient/keywords.txt
+++ b/firmware/lib/NTPClient/keywords.txt
@@ -1,0 +1,24 @@
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+NTPClient	KEYWORD1
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+
+begin	KEYWORD2
+end	KEYWORD2
+update	KEYWORD2
+forceUpdate	KEYWORD2
+isTimeSet	KEYWORD2
+getDay	KEYWORD2
+getHours	KEYWORD2
+getMinutes	KEYWORD2
+getSeconds	KEYWORD2
+getFormattedTime	KEYWORD2
+getEpochTime	KEYWORD2
+setTimeOffset	KEYWORD2
+setUpdateInterval	KEYWORD2
+setPoolServerName	KEYWORD2

--- a/firmware/lib/NTPClient/library.properties
+++ b/firmware/lib/NTPClient/library.properties
@@ -1,0 +1,9 @@
+name=NTPClient
+version=3.2.1
+author=Fabrice Weinberg
+maintainer=Fabrice Weinberg <fabrice@weinberg.me>
+sentence=An NTPClient to connect to a time server
+paragraph=Get time from a NTP server and keep it in sync.
+category=Timing
+url=https://github.com/arduino-libraries/NTPClient
+architectures=*

--- a/platformio.ini
+++ b/platformio.ini
@@ -59,7 +59,6 @@ lib_deps =
 	SPIFFS
 	LittleFS
 	SD
-	arduino-libraries/NTPClient@^3.2.1
 	bblanchon/ArduinoJson@^7.0.4
 	bblanchon/StreamUtils@^1.9.0
 	bodmer/TFT_eSPI@^2.5.43


### PR DESCRIPTION
Integrate NTPClient library to fix upstream bug. 
This should allow us to simplify the logic in GlobalTime.cpp. 
The clock is kept at 0:00 until we got a valid NTP response.

See https://github.com/arduino-libraries/NTPClient/pull/211/files