### PR TITLE
Log before releasing the semaphore

### DIFF
--- a/firmware/src/core/utils/TaskManager.cpp
+++ b/firmware/src/core/utils/TaskManager.cpp
@@ -99,8 +99,8 @@ void TaskManager::processAwaitingTasks() {
             // Serial.printf("TaskParams deleted: %d\n", taskParamsCount);
 
             Utils::setBusy(false);
+            Log.noticeln("✅ Release semaphore");
             xSemaphoreGive(taskSemaphore);
-            Log.noticeln("✅ Released semaphore");
             vTaskDelete(nullptr);
         },
         "TASK_EXEC",


### PR DESCRIPTION
This should fix a concurrency problem in the log.