### PR TITLE
Switch to new API provider for the timeZone information

### DIFF
--- a/firmware/config/config.system.h
+++ b/firmware/config/config.system.h
@@ -102,7 +102,7 @@
 #endif
 
 #ifndef TIMEZONE_API_URL
-    #define TIMEZONE_API_URL "https://timeapi.io/api/timezone/zone"
+    #define TIMEZONE_API_URL "http://timeapi.io/api/timezone/zone"
 #endif
 
 #ifndef WEATHER_API_KEY

--- a/firmware/config/config.system.h
+++ b/firmware/config/config.system.h
@@ -105,8 +105,14 @@
     #define TIMEZONE_API_KEY "97R9WKDPBLIO"
 #endif
 
-#ifndef TIMEZONE_API_URL
-    #define TIMEZONE_API_URL "http://api.timezonedb.com/v2.1/get-time-zone"
+#ifndef TIMEZONE_API
+    #ifndef TIMEZONE_API_URL
+        #define TIMEZONE_API_URL "http://api.timezonedb.com/v2.1/get-time-zone"
+    #endif
+#else
+    #ifndef TIMEZONE_API_URL
+        #define TIMEZONE_API_URL "https://timeapi.io/api/timezone/zone"
+    #endif
 #endif
 
 #ifndef WEATHER_API_KEY

--- a/firmware/config/config.system.h
+++ b/firmware/config/config.system.h
@@ -102,7 +102,7 @@
 #endif
 
 #ifndef TIMEZONE_API_URL
-    #define TIMEZONE_API_URL "http://timeapi.io/api/timezone/zone"
+    #define TIMEZONE_API_URL "https://timeapi.io/api/timezone/zone"
 #endif
 
 #ifndef WEATHER_API_KEY

--- a/firmware/config/config.system.h
+++ b/firmware/config/config.system.h
@@ -101,18 +101,8 @@
     #define SPI_FREQUENCY 27000000
 #endif
 
-#ifndef TIMEZONE_API_KEY
-    #define TIMEZONE_API_KEY "97R9WKDPBLIO"
-#endif
-
-#ifndef TIMEZONE_API
-    #ifndef TIMEZONE_API_URL
-        #define TIMEZONE_API_URL "http://api.timezonedb.com/v2.1/get-time-zone"
-    #endif
-#else
-    #ifndef TIMEZONE_API_URL
-        #define TIMEZONE_API_URL "https://timeapi.io/api/timezone/zone"
-    #endif
+#ifndef TIMEZONE_API_URL
+    #define TIMEZONE_API_URL "https://timeapi.io/api/timezone/zone"
 #endif
 
 #ifndef WEATHER_API_KEY

--- a/firmware/src/core/globaltime/GlobalTime.cpp
+++ b/firmware/src/core/globaltime/GlobalTime.cpp
@@ -143,13 +143,19 @@ bool GlobalTime::isPM() {
 
 void GlobalTime::getTimeZoneOffsetFromAPI() {
     HTTPClient http;
+#ifndef TIMEZONE_API
     http.begin(String(TIMEZONE_API_URL) + "?key=" + TIMEZONE_API_KEY + "&format=json&fields=gmtOffset,zoneEnd&by=zone&zone=" + String(m_timezoneLocation.c_str()));
+#else
+    http.begin(String(TIMEZONE_API_URL) + "?timeZone=" + String(m_timezoneLocation.c_str()));
+#endif
+
     int httpCode = http.GET();
 
     if (httpCode > 0) {
         JsonDocument doc;
         DeserializationError error = deserializeJson(doc, http.getString());
         if (!error) {
+#ifndef TIMEZONE_API
             m_timeZoneOffset = doc["gmtOffset"].as<int>();
             if (doc["zoneEnd"].isNull()) {
                 // Timezone does not use DST, no futher updates necessary
@@ -158,6 +164,31 @@ void GlobalTime::getTimeZoneOffsetFromAPI() {
                 // Timezone uses DST, update when necessary
                 m_nextTimeZoneUpdate = doc["zoneEnd"].as<unsigned long>() + random(5 * 60); // Randomize update by 5 minutes to avoid flooding the API
             }
+#else
+            m_timeZoneOffset = doc["currentUtcOffset"]["seconds"].as<int>();
+            if (doc["hasDayLightSaving"].as<bool>()) {
+                String dstStart = doc["dstInterval"]["dstStart"].as<String>();
+                String dstEnd = doc["dstInterval"]["dstEnd"].as<String>();
+                bool dstActive = doc["isDayLightSavingActive"].as<bool>();
+                tmElements_t m_temp_t;
+                if (dstActive) {
+                    m_temp_t.Year = dstEnd.substring(0, 4).toInt() - 1970;
+                    m_temp_t.Month = dstEnd.substring(5, 7).toInt();
+                    m_temp_t.Day = dstEnd.substring(8, 10).toInt();
+                    m_temp_t.Hour = dstEnd.substring(11, 13).toInt();
+                    m_temp_t.Minute = dstEnd.substring(14, 16).toInt();
+                    m_temp_t.Second = dstEnd.substring(17, 19).toInt();
+                } else {
+                    m_temp_t.Year = dstStart.substring(0, 4).toInt() - 1970;
+                    m_temp_t.Month = dstStart.substring(5, 7).toInt();
+                    m_temp_t.Day = dstStart.substring(8, 10).toInt();
+                    m_temp_t.Hour = dstStart.substring(11, 13).toInt();
+                    m_temp_t.Minute = dstStart.substring(14, 16).toInt();
+                    m_temp_t.Second = dstStart.substring(17, 19).toInt();
+                }
+                m_nextTimeZoneUpdate = makeTime(m_temp_t) + random(5 * 60); // Randomize update by 5 minutes to avoid flooding the API;
+            }
+#endif
             Serial.print("Timezone Offset from API: ");
             Serial.println(m_timeZoneOffset);
             Serial.print("Next timezone update: ");

--- a/firmware/src/core/globaltime/GlobalTime.cpp
+++ b/firmware/src/core/globaltime/GlobalTime.cpp
@@ -189,16 +189,13 @@ void GlobalTime::getTimeZoneOffsetFromAPI() {
                 m_nextTimeZoneUpdate = makeTime(m_temp_t) + random(5 * 60); // Randomize update by 5 minutes to avoid flooding the API;
             }
 #endif
-            Serial.print("Timezone Offset from API: ");
-            Serial.println(m_timeZoneOffset);
-            Serial.print("Next timezone update: ");
-            Serial.println(m_nextTimeZoneUpdate);
+            Log.infoln("Timezone Offset from API: %d; Next timezone update: %d", m_timeZoneOffset, m_nextTimeZoneUpdate);
             m_timeClient->setTimeOffset(m_timeZoneOffset);
         } else {
-            Serial.println("Deserialization error on timezone offset API response");
+            Log.warningln("Deserialization error on timezone offset API response");
         }
     } else {
-        Serial.println("Failed to get timezone offset from API");
+        Log.warningln("Failed to get timezone offset from API");
     }
 }
 


### PR DESCRIPTION
Objective of the change:
- Using the "TIMEZONE_API" variable in config.system.h to switch between API providers for time zone information.

Benefits:
- The new API doesn't require an API key
- The new API doesn't have a limit of 1 call per second (which is a feature required for a multi-zone clock).

I have made the modification backwards compatible with the current version for calculating when the daylight savings change will occur.

