### PR TITLE
Switching to using extends

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -18,6 +18,9 @@ data_dir = build/littlefs
 
 [common]
 ; Common settings for all boards
+platform = espressif32
+board = esp32doit-devkit-v1
+
 board_build.embed_files = 
 	images/logo.jpg
 
@@ -92,37 +95,30 @@ build_flags =
 	-I firmware/src/widgets
 	-include "firmware/config/config_helper.h"
 
+monitor_filters =
+	direct
+	time
+	esp32_exception_decoder 
 
 [env:infoorbs-v0_3]
-platform = espressif32
-board = esp32doit-devkit-v1
-board_build.embed_files = ${common.board_build.embed_files}
-board_build.partitions = ${common.board_build.partitions}
-board_build.filesystem = ${common.board_build.filesystem}
-framework = ${common.framework}
-lib_deps = ${common.lib_deps}
-monitor_speed = ${common.monitor_speed}
-extra_scripts = ${common.extra_scripts}
+extends = common
+
 build_flags = 
     ${common.build_flags}
+	-D WM_NODEBUG
     -D PCB_VERSION="\"infoorbs-v0_3\""
 
 [env:infoorbs-v0_3x-debug]
-platform = espressif32
-board = esp32doit-devkit-v1
-board_build.embed_files = ${common.board_build.embed_files}
+extends = common
+
 board_build.partitions = partitions-debug.csv
-board_build.filesystem = ${common.board_build.filesystem}
-framework = ${common.framework}
-lib_deps = ${common.lib_deps}
-monitor_speed = ${common.monitor_speed}
-extra_scripts = ${common.extra_scripts}
+debug_tool = esp-prog
+debug_init_break = tbreak setup
+build_type = debug
+debug_build_flags = -O0 -g -ggdb
+
 build_flags = 
     ${common.build_flags}
     -D PCB_VERSION="\"infoorbs-v0_3x\""
 	-D SCREEN_1_CS=0
 	-D BUTTON_RIGHT_PIN=5
-debug_tool = esp-prog
-debug_init_break = tbreak setup
-build_type = debug
-debug_build_flags = -O0 -g -ggdb


### PR DESCRIPTION
# Description
Switching to using the `extends` keyword instead of duplicating the config.  [reference](https://docs.platformio.org/en/latest/projectconf/sections/env/options/advanced/extends.html)