### PR TITLE
Set a default Logging level

### DIFF
--- a/firmware/config/config.h.template
+++ b/firmware/config/config.h.template
@@ -73,7 +73,7 @@
 
 // Log levels: LOG_LEVEL_SILENT, LOG_LEVEL_FATAL, LOG_LEVEL_ERROR, 
 // LOG_LEVEL_WARNING, LOG_LEVEL_INFO, LOG_LEVEL_TRACE, LOG_LEVEL_VERBOSE (NOTICE is the same as INFO, it's kept for backward compatability)
-#define LOG_LEVEL LOG_LEVEL_INFO
+// #define LOG_LEVEL LOG_LEVEL_INFO
 
 // Include current time in all log output
 // #define LOG_TIMESTAMP

--- a/firmware/config/config.system.h
+++ b/firmware/config/config.system.h
@@ -117,4 +117,8 @@
     #define MAX_RETRIES 3
 #endif
 
+#ifndef LOG_LEVEL
+    #define LOG_LEVEL LOG_LEVEL_INFO
+#endif
+
 #endif


### PR DESCRIPTION
set default logging level, if user never enables it in their own conf.h then it's set to LOG_LEVEL_INFO