### PR TITLE
Update WifiManagerCustomParameters.h

### DIFF
--- a/firmware/include/WifiManagerCustomParameters.h
+++ b/firmware/include/WifiManagerCustomParameters.h
@@ -109,7 +109,7 @@ class FloatParameter : public WiFiManagerParameter {
     using WiFiManagerParameter::getValue; // make parent function private
 public:
     FloatParameter(const char *id, const char *placeholder, float value, const uint8_t length = 10) {
-        init(id, placeholder, String(value).c_str(), length, "", WFM_LABEL_BEFORE);
+        init(id, placeholder, String(value,4).c_str(), length, "", WFM_LABEL_BEFORE);
     }
 
     float getValue() {


### PR DESCRIPTION
like to issue #274 "Value of a float is being truncated when passed to addConfigFloat"

Allow 4 decimal places for float rather than the default 2 on the conversion to a string.

In an ideal world this should be a parameter to say how many decimal places are required..