### PR TITLE
Minor fix to weather units in WeatherWidget

### DIFF
--- a/firmware/src/widgets/weatherwidget/WeatherWidget.cpp
+++ b/firmware/src/widgets/weatherwidget/WeatherWidget.cpp
@@ -19,7 +19,6 @@
 
 WeatherWidget::WeatherWidget(ScreenManager &manager, ConfigManager &config)
     : Widget(manager, config),
-      m_weatherUnits(0),
       m_drawTimer(addDrawRefreshFrequency(WEATHER_DRAW_DELAY)),
       m_updateTimer(addUpdateRefreshFrequency(WEATHER_UPDATE_DELAY)) {
     m_enabled = true; // Enabled by default


### PR DESCRIPTION
m_weatherUnits was getting initialized twice causing it to always be celsius regardless of how it was set in the config.h file