### PR TITLE
Increase widget limit and do not add disabled widgets

### DIFF
--- a/firmware/config/config.system.h
+++ b/firmware/config/config.system.h
@@ -84,7 +84,7 @@
 // Maximum number of enabled widgets
 // The ESP might run out of memory if this is set too high
 #ifndef MAX_WIDGETS
-    #define MAX_WIDGETS 5
+    #define MAX_WIDGETS 7
 #endif
 
 #ifndef SCREEN_SIZE

--- a/firmware/config/config.system.h
+++ b/firmware/config/config.system.h
@@ -81,6 +81,12 @@
     #define NTP_SERVER "pool.ntp.org"
 #endif
 
+// Maximum number of enabled widgets
+// The ESP might run out of memory if this is set too high
+#ifndef MAX_WIDGETS
+    #define MAX_WIDGETS 5
+#endif
+
 #ifndef SCREEN_SIZE
     #define SCREEN_SIZE 240
 #endif

--- a/firmware/src/core/widget/WidgetSet.cpp
+++ b/firmware/src/core/widget/WidgetSet.cpp
@@ -5,6 +5,10 @@ WidgetSet::WidgetSet(ScreenManager *sm) : m_screenManager(sm) {
 }
 
 void WidgetSet::add(Widget *widget) {
+    if (!widget->isEnabled()) {
+        Log.infoln("Widget %s is disabled", widget->getName().c_str());
+        return;
+    }
     if (m_widgetCount == MAX_WIDGETS) {
         Log.warningln("MAX WIDGETS UNABLE TO ADD");
         return;

--- a/firmware/src/core/widget/WidgetSet.h
+++ b/firmware/src/core/widget/WidgetSet.h
@@ -5,7 +5,9 @@
 #include "Utils.h"
 #include "Widget.h"
 
-#define MAX_WIDGETS 10
+#ifndef MAX_WIDGETS
+    #define MAX_WIDGETS 5
+#endif
 
 class WidgetSet {
 public:

--- a/firmware/src/core/widget/WidgetSet.h
+++ b/firmware/src/core/widget/WidgetSet.h
@@ -5,7 +5,7 @@
 #include "Utils.h"
 #include "Widget.h"
 
-#define MAX_WIDGETS 5
+#define MAX_WIDGETS 10
 
 class WidgetSet {
 public:


### PR DESCRIPTION
The maximum number of widgets has been raised from 5 to 10 to allow greater flexibility. A check was also added to log and prevent adding disabled widgets, improving robustness and debugging capabilities.