### PR TITLE
Quick fix for clockwidget missing digits when switching widgets back and forth 

### DIFF
--- a/firmware/src/core/widget/WidgetSet.cpp
+++ b/firmware/src/core/widget/WidgetSet.cpp
@@ -76,7 +76,6 @@ void WidgetSet::prev() {
 void WidgetSet::switchWidget() {
     m_screenManager->clearAllScreens();
     getCurrent()->setup();
-    getCurrent()->update();
     uint32_t start = millis();
     getCurrent()->draw(true);
     uint32_t end = millis();


### PR DESCRIPTION
removed call to getCurrent()->update(); during switchWidget as it's causing the ClockWidget to draw with missing digits  issue #310