### PR TITLE
Quick fix on Async Task stack size

### DIFF
--- a/firmware/src/core/utils/TaskManager.h
+++ b/firmware/src/core/utils/TaskManager.h
@@ -83,7 +83,7 @@ private:
 
     static TaskManager *instance;
 
-    static const uint16_t STACK_SIZE = 12000;
+    static const uint16_t STACK_SIZE = 6000;
     static const UBaseType_t TASK_PRIORITY = 1;
     static const UBaseType_t REQUEST_QUEUE_SIZE = 20;
     static const UBaseType_t REQUEST_QUEUE_ITEM_SIZE = sizeof(TaskParams *);


### PR DESCRIPTION
Per issue #313 PR #268 changed the Async stack size from 6000 to 12000. This is causing the app to run out of memory in certain situations.  This change moves the stack size back to 6000