### PR TITLE
New WidgetRegistry - Only include non disabled widgets in the compiled binary

### DIFF
--- a/firmware/src/core/widget/WidgetRegistry.cpp
+++ b/firmware/src/core/widget/WidgetRegistry.cpp
@@ -1,0 +1,68 @@
+#include "WidgetRegistry.h"
+
+// Include widget headers
+#include "clockwidget/ClockWidget.h"
+#if INCLUDE_WEATHER != WIDGET_DISABLED
+    #include "weatherwidget/WeatherWidget.h"
+#endif
+#if INCLUDE_STOCK != WIDGET_DISABLED
+    #include "stockwidget/StockWidget.h"
+#endif
+#if INCLUDE_PARQET != WIDGET_DISABLED
+    #include "parqetwidget/ParqetWidget.h"
+#endif
+#if INCLUDE_WEBDATA != WIDGET_DISABLED
+    #ifdef WEB_DATA_WIDGET_URL
+        #include "webdatawidget/WebDataWidget.h"
+    #endif
+    #ifdef WEB_DATA_STOCK_WIDGET_URL
+        #include "webdatawidget/WebDataWidget.h"
+    #endif
+#endif
+#if INCLUDE_MQTT != WIDGET_DISABLED
+    #include "mqttwidget/MQTTWidget.h"
+#endif
+#if INCLUDE_5ZONE != WIDGET_DISABLED
+    #include "5zonewidget/5ZoneWidget.h"
+#endif
+#if INCLUDE_MATRIXSCREEN != WIDGET_DISABLED
+    #include "matrixwidget/MatrixWidget.h"
+#endif
+
+void registerWidgets(WidgetSet *widgetSet, ScreenManager *sm, ConfigManager *config) {
+    // Always add clock widget
+    widgetSet->add(new ClockWidget(*sm, *config));
+
+#if INCLUDE_WEATHER != WIDGET_DISABLED
+    widgetSet->add(new WeatherWidget(*sm, *config));
+#endif
+
+#if INCLUDE_STOCK != WIDGET_DISABLED
+    widgetSet->add(new StockWidget(*sm, *config));
+#endif
+
+#if INCLUDE_PARQET != WIDGET_DISABLED
+    widgetSet->add(new ParqetWidget(*sm, *config));
+#endif
+
+#if INCLUDE_WEBDATA != WIDGET_DISABLED
+    #ifdef WEB_DATA_WIDGET_URL
+    widgetSet->add(new WebDataWidget(*sm, *config, WEB_DATA_WIDGET_URL));
+    #endif
+    #ifdef WEB_DATA_STOCK_WIDGET_URL
+    widgetSet->add(new WebDataWidget(*sm, *config, WEB_DATA_STOCK_WIDGET_URL));
+    #endif
+#endif
+
+#if INCLUDE_MQTT != WIDGET_DISABLED
+    widgetSet->add(new MQTTWidget(*sm, *config));
+#endif
+
+#if INCLUDE_5ZONE != WIDGET_DISABLED
+    widgetSet->add(new FiveZoneWidget(*sm, *config));
+#endif
+
+#if INCLUDE_MATRIXSCREEN != WIDGET_DISABLED
+    widgetSet->add(new MatrixWidget(*sm, *config));
+#endif
+}

--- a/firmware/src/core/widget/WidgetRegistry.cpp
+++ b/firmware/src/core/widget/WidgetRegistry.cpp
@@ -1,6 +1,7 @@
 #include "WidgetRegistry.h"
 
-// Include widget headers
+// Include widget headers, always wrap them in a check for WIDGET_DISABLED
+// to avoid including them in the build if they are disabled
 #include "clockwidget/ClockWidget.h"
 #if INCLUDE_WEATHER != WIDGET_DISABLED
     #include "weatherwidget/WeatherWidget.h"
@@ -33,6 +34,7 @@ void registerWidgets(WidgetSet *widgetSet, ScreenManager *sm, ConfigManager *con
     // Always add clock widget
     widgetSet->add(new ClockWidget(*sm, *config));
 
+// Add other widgets based on compile-time flags, and only if they are not disabled
 #if INCLUDE_WEATHER != WIDGET_DISABLED
     widgetSet->add(new WeatherWidget(*sm, *config));
 #endif

--- a/firmware/src/core/widget/WidgetRegistry.h
+++ b/firmware/src/core/widget/WidgetRegistry.h
@@ -1,0 +1,11 @@
+#ifndef WIDGET_REGISTRY_H
+#define WIDGET_REGISTRY_H
+
+#include "ConfigManager.h"
+#include "ScreenManager.h"
+#include "WidgetSet.h"
+
+// Registers all widgets with the widget set.
+void registerWidgets(WidgetSet *widgetSet, ScreenManager *sm, ConfigManager *config);
+
+#endif // WIDGET_REGISTRY_H

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -1,8 +1,8 @@
 #include "GlobalResources.h"
-#include "GlobalTime.h" // Added to declare GlobalTime
+#include "GlobalTime.h"
 #include "MainHelper.h"
 #include "TaskFactory.h"
-#include "WidgetRegistry.h" // New include for widget registration
+#include "WidgetRegistry.h"
 #include "wifiwidget/WifiWidget.h"
 #include <ArduinoLog.h>
 
@@ -57,7 +57,6 @@ void setup() {
 
     globalTime = GlobalTime::getInstance();
 
-    // Register widgets using the WidgetRegistry module
     registerWidgets(widgetSet, sm, config);
 
     config->setupWebPortal();

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -1,13 +1,8 @@
-#include "5zonewidget/5ZoneWidget.h"
 #include "GlobalResources.h"
+#include "GlobalTime.h" // Added to declare GlobalTime
 #include "MainHelper.h"
-#include "clockwidget/ClockWidget.h"
-#include "matrixwidget/MatrixWidget.h"
-#include "mqttwidget/MQTTWidget.h"
-#include "parqetwidget/ParqetWidget.h"
-#include "stockwidget/StockWidget.h"
-#include "weatherwidget/WeatherWidget.h"
-#include "webdatawidget/WebDataWidget.h"
+#include "TaskFactory.h"
+#include "WidgetRegistry.h" // New include for widget registration
 #include "wifiwidget/WifiWidget.h"
 #include <ArduinoLog.h>
 
@@ -19,39 +14,6 @@ ScreenManager *sm{nullptr};
 ConfigManager *config{nullptr};
 OrbsWiFiManager *wifiManager{nullptr};
 WidgetSet *widgetSet{nullptr};
-
-void addWidgets() {
-    // Always add clock
-    widgetSet->add(new ClockWidget(*sm, *config));
-
-#if INCLUDE_WEATHER != WIDGET_DISABLED
-    widgetSet->add(new WeatherWidget(*sm, *config));
-#endif
-
-#if INCLUDE_STOCK != WIDGET_DISABLED
-    widgetSet->add(new StockWidget(*sm, *config));
-#endif
-#if INCLUDE_PARQET != WIDGET_DISABLED
-    widgetSet->add(new ParqetWidget(*sm, *config));
-#endif
-#if INCLUDE_WEBDATA != WIDGET_DISABLED
-    #ifdef WEB_DATA_WIDGET_URL
-    widgetSet->add(new WebDataWidget(*sm, *config, WEB_DATA_WIDGET_URL));
-    #endif
-    #ifdef WEB_DATA_STOCK_WIDGET_URL
-    widgetSet->add(new WebDataWidget(*sm, *config, WEB_DATA_STOCK_WIDGET_URL));
-    #endif
-#endif
-#if INCLUDE_MQTT != WIDGET_DISABLED
-    widgetSet->add(new MQTTWidget(*sm, *config));
-#endif
-#if INCLUDE_5ZONE != WIDGET_DISABLED
-    widgetSet->add(new FiveZoneWidget(*sm, *config));
-#endif
-#if INCLUDE_MATRIXSCREEN != WIDGET_DISABLED
-    widgetSet->add(new MatrixWidget(*sm, *config));
-#endif
-}
 
 void setup() {
     // Initialize global resources
@@ -94,7 +56,10 @@ void setup() {
     wifiWidget->setup();
 
     globalTime = GlobalTime::getInstance();
-    addWidgets();
+
+    // Register widgets using the WidgetRegistry module
+    registerWidgets(widgetSet, sm, config);
+
     config->setupWebPortal();
     MainHelper::resetCycleTimer();
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,6 +18,8 @@ data_dir = build/littlefs
 
 [common]
 ; Common settings for all boards
+platform = espressif32
+board = esp32doit-devkit-v1
 board_build.embed_files = 
 	images/logo.jpg
 
@@ -68,6 +70,11 @@ lib_deps =
 	tzapu/WiFiManager@^2.0.17
 	thijse/ArduinoLog@^1.1.1
 monitor_speed = 115200
+monitor_filters =
+    direct
+    #time
+    esp32_exception_decoder
+
 extra_scripts =
 	; Get git branch/commit info
 	pre:scripts/generate_git_info.py
@@ -97,35 +104,21 @@ build_flags =
 
 
 [env:infoorbs-v0_3]
-platform = espressif32
-board = esp32doit-devkit-v1
-board_build.embed_files = ${common.board_build.embed_files}
-board_build.partitions = ${common.board_build.partitions}
-board_build.filesystem = ${common.board_build.filesystem}
-framework = ${common.framework}
-lib_deps = ${common.lib_deps}
-monitor_speed = ${common.monitor_speed}
-extra_scripts = ${common.extra_scripts}
+extends = common
 build_flags = 
     ${common.build_flags}
     -D PCB_VERSION="\"infoorbs-v0_3\""
 
 [env:infoorbs-v0_3x-debug]
-platform = espressif32
-board = esp32doit-devkit-v1
-board_build.embed_files = ${common.board_build.embed_files}
+extends = common
 board_build.partitions = partitions-debug.csv
-board_build.filesystem = ${common.board_build.filesystem}
-framework = ${common.framework}
-lib_deps = ${common.lib_deps}
-monitor_speed = ${common.monitor_speed}
-extra_scripts = ${common.extra_scripts}
+debug_tool = esp-prog
+debug_init_break = tbreak setup
+build_type = debug
+debug_build_flags = -O0 -g -ggdb
 build_flags = 
     ${common.build_flags}
     -D PCB_VERSION="\"infoorbs-v0_3x\""
 	-D SCREEN_1_CS=0
 	-D BUTTON_RIGHT_PIN=5
-debug_tool = esp-prog
-debug_init_break = tbreak setup
-build_type = debug
-debug_build_flags = -O0 -g -ggdb
+

--- a/platformio.ini
+++ b/platformio.ini
@@ -78,6 +78,9 @@ extra_scripts =
 	; Automatically upload LittleFS partition
 	pre:scripts/upload_littlefs.py
 build_flags = 
+    -ffunction-sections 
+    -fdata-sections 
+    -Wl,--gc-sections
 	-D DISABLE_ALL_LIBRARY_WARNINGS
 	-D USER_SETUP_LOADED=1
 	-Wfatal-errors


### PR DESCRIPTION
**Current Issue:**  
As we add more widgets, our compiled binary grows because every widget is included in the compilation, even disabled ones.  

**Solution:**  
This change moves widget registration out of `main.cpp` and into a dedicated file (`WidgetRegistry.cpp`). Now:  
- Only enabled widgets are included in the build.  
- `main.cpp` is cleaner—it just needs to call `registerWidgets(widgetSet, sm, config)`.  

This change also adds a couple build flags to the platformio.ini to help reduce the final binary size by eliminating unused code and data.  And also switches the platformio.ini to use extends.

**How to Add a New Widget:**  
1. Add your widget code to the repo.  
2. Register it in `WidgetRegistry.cpp` and `config.system.h`.  

This makes the build more efficient and keeps the codebase better organized.