### PR TITLE
Visual Crossing Weather - Allow user defined additional query params

### DIFF
--- a/firmware/src/widgets/weatherwidget/feeds/VisualCrossingFeed.cpp
+++ b/firmware/src/widgets/weatherwidget/feeds/VisualCrossingFeed.cpp
@@ -24,7 +24,7 @@ bool VisualCrossingFeed::getWeatherData(WeatherDataModel &model) {
 
     String httpRequestAddress = String(WEATHER_VISUALCROSSING_API_URL) +
                                 String(m_weatherLocation.c_str()) + "/next3days?key=" + apiKey + "&unitGroup=" + tempUnits +
-                                "&include=days,current&iconSet=icons1&lang=" + lang;
+                                "&include=days,current&iconSet=icons1&lang=" + lang + String(WEATHER_VISUALCROSSING_ADDITIONAL_QUERY_PARAMS);
 
     auto task = TaskFactory::createHttpGetTask(
         httpRequestAddress, [this, &model](int httpCode, const String &response) { processResponse(httpCode, response, model); }, [this](int httpCode, String &response) { preProcessResponse(httpCode, response); });

--- a/firmware/src/widgets/weatherwidget/feeds/VisualCrossingFeed.h
+++ b/firmware/src/widgets/weatherwidget/feeds/VisualCrossingFeed.h
@@ -10,6 +10,10 @@
     #define WEATHER_VISUALCROSSING_API_URL "https://weather.visualcrossing.com/VisualCrossingWebServices/rest/services/timeline/"
 #endif
 
+#ifndef WEATHER_VISUALCROSSING_ADDITIONAL_QUERY_PARAMS
+    #define WEATHER_VISUALCROSSING_ADDITIONAL_QUERY_PARAMS ""
+#endif
+
 class VisualCrossingFeed : public WeatherFeed {
 public:
     VisualCrossingFeed(const String &apiKey, int units);


### PR DESCRIPTION
Add the ability to define extra query string params for visual crossing weather API.  This allows you to add options like include only level one stations if that helps improve the weather data for your location.  

```bash
#define WEATHER_VISUALCROSSING_ADDITIONAL_QUERY_PARAMS "&options=stnslevel1"
```
