### PR TITLE
Implement automatic dimming capability

### DIFF
--- a/firmware/config/config.h.template
+++ b/firmware/config/config.h.template
@@ -29,6 +29,12 @@
 // #define DIM_END_HOUR 7     // Undim the screens at this time (24h format)
 // #define DIM_BRIGHTNESS 128 // Dim brightness (0-255)
 
+// AUTO DIMMING (requires hardware mod -- SEE config.system.h)
+#define AUTO_DIMMING_ENABLED false // (true or false)
+#define AUTO_BRIGHTNESS_MIN 80     // (0-255)
+#define AUTO_BRIGHTNESS_MAX 255    // (0-255)
+#define NUM_BRIGHTNESS_LEVELS 10   // (2 or greater)
+
 // TRUETYPE FONT CONFIGURATION
 // #define DEFAULT_FONT ROBOTO_REGULAR
 

--- a/firmware/config/config.system.h
+++ b/firmware/config/config.system.h
@@ -78,8 +78,8 @@
 #endif
 
 // Ambient light sensing for auto dimming. Must have photoresistor hardware mod.
-// This entails wiring a photoresistor (200 ohm to 10 Mohm range measured) between
-// GPIO34 and 3.3v; and a 22K resistor between GPIO34 and gnd.
+// This entails wiring a GL5537 photoresistor between GPIO34 and 3.3v; and a
+// 22K resistor between GPIO34 and gnd.
 #define LIGHT_SENSE_PIN 34
 #define LIGHT_MIN 0    // (0-4095)
 #define LIGHT_MAX 4095 // (0-4095)

--- a/firmware/config/config.system.h
+++ b/firmware/config/config.system.h
@@ -77,6 +77,13 @@
     #define BUSY_PIN 2
 #endif
 
+// Ambient light sensing for auto dimming. Must have photoresistor hardware mod.
+// This entails wiring a photoresistor (200 ohm to 10 Mohm range measured) between
+// GPIO34 and 3.3v; and a 22K resistor between GPIO34 and gnd.
+#define LIGHT_SENSE_PIN 34
+#define LIGHT_MIN 0    // (0-4095)
+#define LIGHT_MAX 4095 // (0-4095)
+
 #ifndef NTP_SERVER
     #define NTP_SERVER "pool.ntp.org"
 #endif

--- a/firmware/src/core/autodimming/DimmingManager.cpp
+++ b/firmware/src/core/autodimming/DimmingManager.cpp
@@ -1,3 +1,5 @@
+#if AUTO_DIMMING_ENABLED
+
 #include "DimmingManager.h"
 #include <Arduino.h>
 #include <ArduinoLog.h>
@@ -162,3 +164,5 @@ int16_t DimmingManager::hysteresis(uint16_t newLightIntensity) {
 
     return static_cast<int16_t>(brightnessLevel);
 }
+
+#endif  // AUTO_DIMMING_ENABLED

--- a/firmware/src/core/autodimming/DimmingManager.cpp
+++ b/firmware/src/core/autodimming/DimmingManager.cpp
@@ -1,0 +1,164 @@
+#include "DimmingManager.h"
+#include <Arduino.h>
+#include <ArduinoLog.h>
+#include <algorithm>
+#include <esp_timer.h>
+
+// The Dimming Manager can automatically adjust screen brightness in response to changes
+// in ambient light intensity. The basic approach is to periodically measure the ambient
+// light intensity, quantize it into a dimming level, then set the screen brightness to
+// a value corresponding to the dimming level. To prevent the screen brightness from constantly
+// changing due to small light variations, filtering of the light measurements and hysteresis
+// are performed.
+
+// Validate the relevant configuration parameters at compile time
+static_assert(AUTO_BRIGHTNESS_MIN >= 0, "AUTO_BRIGHTNESS_MIN must not be negative");
+static_assert(AUTO_BRIGHTNESS_MIN < AUTO_BRIGHTNESS_MAX,
+              "AUTO_BRIGHTNESS_MIN must be less than AUTO_BRIGHTNESS_MAX");
+static_assert(AUTO_BRIGHTNESS_MAX < 256, "AUTO_BRIGHTNESS_MAX must be less than 256");
+static_assert(LIGHT_MIN >= 0, "LIGHT_MIN must not be negative");
+static_assert(LIGHT_MIN < LIGHT_MAX, "LIGHT_MIN must be less than LIGHT_MAX");
+static_assert(LIGHT_MAX < 4096, "LIGHT_MAX must be less than 4096");
+static_assert(NUM_BRIGHTNESS_LEVELS > 1, "NUM_BRIGHTNESS_LEVELS must be greater than one");
+
+// Local definitions
+namespace {
+    // These count the number of integer values in the range and are guaranteed greater than one
+    constexpr uint16_t lightDiscreteValues = LIGHT_MAX - LIGHT_MIN + 1;
+    constexpr uint16_t brightnessDiscreteValues = AUTO_BRIGHTNESS_MAX - AUTO_BRIGHTNESS_MIN + 1;
+
+    // numDimmingLevels can be no greater than any of (NUM_BRIGHTNESS_LEVELS, lightDiscreteValues,
+    // brightnessDiscreteValues). It is guaranteed greater than one.
+    constexpr uint16_t temp = ((NUM_BRIGHTNESS_LEVELS < lightDiscreteValues) ?
+                               NUM_BRIGHTNESS_LEVELS : lightDiscreteValues);
+    constexpr uint16_t numDimmingLevels = ((temp < brightnessDiscreteValues) ?
+                                           temp : brightnessDiscreteValues);
+
+    // Used to divide lightScale into quantized brightness levels. Guaranteed greater than zero.
+    constexpr uint16_t lightStepSize = ((lightDiscreteValues - 1) / numDimmingLevels) + 1;
+
+    // Used to multiply brightness levels into screen brightness values. Brightest value possible
+    // may be slightly less than AUTO_BRIGHTNESS_MAX due to quantization. Guaranteed greater
+    // than zero.
+    constexpr uint16_t brightnessStepSize = (brightnessDiscreteValues - 1) / (numDimmingLevels - 1);
+
+    // Return the integer closest to val, subject to the interval [min, max]
+    template <typename T>
+    inline T clamp(T val, T min, T max) {
+        return std::max(min, std::min(max, val));
+    }
+}
+
+/////////////////////////////////////////////////////////////
+// Static member function that returns the singleton instance
+DimmingManager &DimmingManager::getInstance() {
+    static DimmingManager instance;
+    return instance;
+}
+
+/////////////////////////
+// Setup the hardware for auto dimming
+void DimmingManager::setup() {
+    if (!AUTO_DIMMING_ENABLED) {
+        return;
+    }
+    adcAttachPin(LIGHT_SENSE_PIN);
+    this->lightIntensity_ = analogRead(LIGHT_SENSE_PIN);
+
+    Log.info("Auto Dimming Enabled***********************************\n");
+    Log.info("Light (min/max): %d/%d\n", LIGHT_MIN, LIGHT_MAX);
+    Log.info("Brightness (min/max): %d/%d\n", AUTO_BRIGHTNESS_MIN, AUTO_BRIGHTNESS_MAX);
+    Log.info("Levels (brightness/dimness): %d/%d\n", NUM_BRIGHTNESS_LEVELS, numDimmingLevels);
+    Log.info("Discrete values (light/brightness): %d/%d\n", lightDiscreteValues,
+             brightnessDiscreteValues);
+    Log.info("Step sizes (light/brightness): %d %d\n", lightStepSize, brightnessStepSize);
+    Log.info("*******************************************************\n");
+}
+
+///////////////////////////////////////////////////////////////////////////
+// Adjust the display brightness to account for the ambient light intensity
+void DimmingManager::updateBrightness(ScreenManager *sm, WidgetSet *ws) {
+    // Update only at regular time intervals, so filtering has predictable behavior
+    if (!AUTO_DIMMING_ENABLED || !this->isTimeToUpdate()) {
+        return;
+    }
+
+    // Get the measured light intensity
+    int16_t lightIntensity = analogRead(LIGHT_SENSE_PIN);
+
+    // Filter to remove transients
+    int16_t filtered = this->filter(lightIntensity);
+
+    Log.info("Dimming Lgt:%d Filt:%d Lo:%d Hi:%d Lvl:%d Brt:%d\n",
+             lightIntensity, filtered, this->lowerHysteresis_, this->upperHysteresis_,
+             this->brightnessLevel_, this->screenBrightness_);
+
+    // Apply hysteresis to avoid flickering on brightness boundaries. Brightness level will
+    // be in the interval [0, numDimmingLevels).
+    int16_t level = this->hysteresis(filtered);
+    if (level < 0) {
+        return;
+    }
+    this->brightnessLevel_ = static_cast<uint16_t>(level);
+
+    // Compute new brightness value in the interval [AUTO_BRIGHTNESS_MIN, AUTO_BRIGHTNESS_MAX]
+    this->screenBrightness_ = (this->brightnessLevel_ * brightnessStepSize) + AUTO_BRIGHTNESS_MIN;
+
+    // Update the display
+    sm->setBrightness(this->screenBrightness_);
+    ws->drawCurrent(true);
+}
+
+///////////////////////////////////////////////////////////////////////////
+// Returns whether or not it is time to update and, if so, resets the timer
+bool DimmingManager::isTimeToUpdate() {
+    constexpr uint64_t updateInterval_uS = 100000; // 0.1 seconds
+    uint64_t currentTime_uS = esp_timer_get_time();
+
+    // Compute elapsed time using unsigned arithmetic to correctly handle rollover
+    uint64_t elapsedTime_uS = currentTime_uS - this->lastUpdateTime_uS_;
+
+    if (elapsedTime_uS <= updateInterval_uS) {
+        return false;
+    }
+
+    this->lastUpdateTime_uS_ = currentTime_uS;
+    return true;
+}
+
+//////////////////////////////////////////////////////////////////////////////////
+// Filter the measured light intensity to smooth transients (passing shadows, etc)
+uint16_t DimmingManager::filter(uint16_t newLightIntensity) {
+    // 0 <= alpha < 1; larger alpha produces more smoothing, but slower response time
+    constexpr float alpha = 0.95;
+    constexpr float oneMinusAlpha = 1.0 - alpha;
+
+    this->lightIntensity_ = static_cast<uint16_t>((alpha * this->lightIntensity_) +
+                                                  (oneMinusAlpha * newLightIntensity) + 0.5);
+    return this->lightIntensity_;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////
+// Add hysteresis (stickiness) to brightness levels. This prevents flickering back and forth
+// when the ambient light is near a brightness boundary. Compute brightness level in the
+// interval [0, numDimmingLevels). Return brightness level or -1 if no change.
+int16_t DimmingManager::hysteresis(uint16_t newLightIntensity) {
+    if (newLightIntensity >= this->lowerHysteresis_ && newLightIntensity <= this->upperHysteresis_) {
+        // Hysteresis thresholds not met, so don't update
+        return -1;
+    }
+
+    // Quantize intensity to yield a discrete brightness level in the interval [0, numDimmingLevels)
+    int16_t brightnessLevel =
+        (clamp<uint16_t>(newLightIntensity, LIGHT_MIN, LIGHT_MAX) - LIGHT_MIN) / lightStepSize;
+
+    // Compute the intensity cooresponding to the lower boundary of this brightness level
+    uint16_t boundary = brightnessLevel * lightStepSize + LIGHT_MIN;
+
+    // Compute new hysteresis thresholds
+    uint16_t tolerance = lightStepSize / 10;
+    this->lowerHysteresis_ = (boundary > tolerance) ? boundary - tolerance : 0;
+    this->upperHysteresis_ = boundary + lightStepSize + tolerance;
+
+    return static_cast<int16_t>(brightnessLevel);
+}

--- a/firmware/src/core/autodimming/DimmingManager.h
+++ b/firmware/src/core/autodimming/DimmingManager.h
@@ -1,0 +1,46 @@
+#ifndef DIMMINGMANAGER_H
+#define DIMMINGMANAGER_H
+
+// Include any necessary libraries here
+#include "ScreenManager.h"
+#include "WidgetSet.h"
+#include "config_helper.h"
+
+// Singleton class to handle auto dimming
+class DimmingManager {
+public:
+    // Don't allow copying or assigning the singleton
+    DimmingManager(const DimmingManager &) = delete;
+    DimmingManager &operator=(const DimmingManager &) = delete;
+
+    // Get the one and only instance of the singleton
+    static DimmingManager &getInstance();
+
+    void setup();
+
+    void updateBrightness(ScreenManager *sm, WidgetSet *ws);
+
+private:
+    // Don't allow constructing the singleton from outside its class
+    DimmingManager() {}
+
+    bool isTimeToUpdate();
+
+    uint16_t filter(uint16_t lightIntensity);
+
+    int16_t hysteresis(uint16_t lightIntensity);
+
+    uint16_t lightIntensity_ = LIGHT_MAX;
+
+    uint16_t lowerHysteresis_ = LIGHT_MAX;
+
+    uint16_t upperHysteresis_ = LIGHT_MIN;
+
+    uint16_t brightnessLevel_ = 0;
+
+    uint16_t screenBrightness_ = 0;
+
+    uint64_t lastUpdateTime_uS_ = 0;
+};
+
+#endif // Include guard

--- a/firmware/src/core/autodimming/DimmingManager.h
+++ b/firmware/src/core/autodimming/DimmingManager.h
@@ -1,3 +1,5 @@
+#if AUTO_DIMMING_ENABLED
+
 #ifndef DIMMINGMANAGER_H
 #define DIMMINGMANAGER_H
 
@@ -44,3 +46,5 @@ private:
 };
 
 #endif // Include guard
+
+#endif  // AUTO_DIMMING_ENABLED

--- a/firmware/src/core/autodimming/ReadMe.txt
+++ b/firmware/src/core/autodimming/ReadMe.txt
@@ -1,19 +1,16 @@
 Automatic dimming requires a minor hardware modification to the InfoOrbs circuit. This entails
-adding a photoresistor and a 22K fixed resistor to the breakout section of the circuit board. The
-circuit is shown below. The photoresistor used in the prototype measured about 200 ohms in bright
-sunlight, and about 10 Mohms in darkness. It was obtained from an Elegoo arduino starter kit. It is
-probably a 5549, but photoresistors vary a lot, so the value of the fixed resistor may need to
-be adjusted proportionally to compensate for a photoresistor with different characteristics.
+adding a GL5537 photoresistor and a 22K fixed resistor to the breakout section of the circuit
+board. The circuit is shown below. Note that photoresistors vary a lot, so it may be necessary
+to experiment with the value of the fixed resistor to get the amount of dimming you want. You
+can also try changing the values of AUTO_BRIGHTNESS_MIN and AUTO_BRIGHTNESS_MAX in config.h
 
-Be aware that small values for the fixed resistor will draw more current and could damage
-the resistor or the board. Don't go below about 1K unless you know what you are doing.
 
                     ^ 3.3V
                     |
                     |
                     \
                     /
-                  --\-> Photoresistor
+                  --\-> GL5537 Photoresistor
                     /
                     \
                     |

--- a/firmware/src/core/autodimming/ReadMe.txt
+++ b/firmware/src/core/autodimming/ReadMe.txt
@@ -1,0 +1,32 @@
+Automatic dimming requires a minor hardware modification to the InfoOrbs circuit. This entails
+adding a photoresistor and a 22K fixed resistor to the breakout section of the circuit board. The
+circuit is shown below. The photoresistor used in the prototype measured about 200 ohms in bright
+sunlight, and about 10 Mohms in darkness. It was obtained from an Elegoo arduino starter kit. It is
+probably a 5549, but photoresistors vary a lot, so the value of the fixed resistor may need to
+be adjusted proportionally to compensate for a photoresistor with different characteristics.
+
+Be aware that small values for the fixed resistor will draw more current and could damage
+the resistor or the board. Don't go below about 1K unless you know what you are doing.
+
+                    ^ 3.3V
+                    |
+                    |
+                    \
+                    /
+                  --\-> Photoresistor
+                    /
+                    \
+                    |
+                    |
+                    +--------[GPIO34>
+                    |
+                    |
+                    \
+                    /
+                    \  22K Fixed Resistor
+                    /
+                    \
+                    |
+                    |
+                   GND
+

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -99,9 +99,9 @@ void setup() {
     config->setupWebPortal();
     MainHelper::resetCycleTimer();
 
-    if (AUTO_DIMMING_ENABLED) {
-      DimmingManager::getInstance().setup();
-    }
+#if AUTO_DIMMING_ENABLED
+    DimmingManager::getInstance().setup();
+#endif
 }
 
 void loop() {
@@ -122,12 +122,11 @@ void loop() {
 
         widgetSet->updateCurrent();
 
-        if (AUTO_DIMMING_ENABLED) {
+#if AUTO_DIMMING_ENABLED
           DimmingManager::getInstance().updateBrightness(sm, widgetSet);
-        }
-        else {
+#else
           MainHelper::updateBrightnessByTime(globalTime->getHour24());
-        }
+#endif
 
         widgetSet->drawCurrent();
 

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -9,6 +9,7 @@
 #include "weatherwidget/WeatherWidget.h"
 #include "webdatawidget/WebDataWidget.h"
 #include "wifiwidget/WifiWidget.h"
+#include "DimmingManager.h"
 #include <ArduinoLog.h>
 
 TFT_eSPI tft = TFT_eSPI();
@@ -97,6 +98,10 @@ void setup() {
     addWidgets();
     config->setupWebPortal();
     MainHelper::resetCycleTimer();
+
+    if (AUTO_DIMMING_ENABLED) {
+      DimmingManager::getInstance().setup();
+    }
 }
 
 void loop() {
@@ -116,7 +121,14 @@ void loop() {
         MainHelper::checkButtons();
 
         widgetSet->updateCurrent();
-        MainHelper::updateBrightnessByTime(globalTime->getHour24());
+
+        if (AUTO_DIMMING_ENABLED) {
+          DimmingManager::getInstance().updateBrightness(sm, widgetSet);
+        }
+        else {
+          MainHelper::updateBrightnessByTime(globalTime->getHour24());
+        }
+
         widgetSet->drawCurrent();
 
         MainHelper::checkCycleWidgets();

--- a/platformio.ini
+++ b/platformio.ini
@@ -82,6 +82,7 @@ build_flags =
 	-D USER_SETUP_LOADED=1
 	-Wfatal-errors
 	-I firmware/config
+	-I firmware/src/core/autodimming
 	-I firmware/src/core/button
 	-I firmware/src/core/configmanager
 	-I firmware/src/core/globaltime


### PR DESCRIPTION
Add support for automatic dimming to adjust for changing room brightness. Requires a minor hardware modification described in [ReadMe.txt](https://github.com/user-attachments/files/21323920/ReadMe.txt) .


 This software change can be safely merged since it is disabled by default, and will have no effect unless `AUTO_DIMMING_ENABLED` is set to `true` in config.h


Closes #325


https://github.com/user-attachments/assets/0e3514b4-0801-445c-8f01-bd8083e6f8c7

