### PR TITLE
Plane radar pr

### DIFF
--- a/firmware/config/config.h.template
+++ b/firmware/config/config.h.template
@@ -16,6 +16,7 @@
 #define INCLUDE_MQTT WIDGET_DISABLED
 #define INCLUDE_5ZONE WIDGET_OFF
 #define INCLUDE_MATRIXSCREEN WIDGET_OFF
+#define INCLUDE_PLANE_RADAR WIDGET_OFF
 
 // WEATHER FEED SELECTION (ONLY SET ONE FEED TO TRUE)
 #define WEATHER_VISUALCROSSING_FEED true
@@ -100,6 +101,14 @@
 // WEB DATA CONFIGURATION
 // #define WEB_DATA_WIDGET_URL "" // Use this to make your own widgets using an API/Webdata source
 // #define WEB_DATA_STOCK_WIDGET_URL "http://<insert host here>/stocks.php?stocks=SPY,VT,GOOG,TSLA,GME" // Use this as an alternative to the stock ticker widget
+
+// PLANE RADAR (live ADS-B — inspired by https://github.com/MatixYo/ESP32-Plane-Radar)
+// #define PLANE_RADAR_LAT 48.4284
+// #define PLANE_RADAR_LON -123.3656
+// #define PLANE_RADAR_RANGE_INDEX 1
+// #define PLANE_RADAR_FETCH_INTERVAL_SEC 3
+// #define PLANE_RADAR_CYCLE_DELAY 180
+// #define PLANE_RADAR_UNITS_METRIC
 
 // MQTT CONFIGURATION
 // #define MQTT_WIDGET_HOST "192.168.3.40" // MQTT broker host

--- a/firmware/config/config.system.h
+++ b/firmware/config/config.system.h
@@ -238,3 +238,22 @@
 #endif
 
 #endif
+
+#ifndef INCLUDE_PLANE_RADAR
+    #define INCLUDE_PLANE_RADAR WIDGET_OFF
+#endif
+#ifndef PLANE_RADAR_LAT
+    #define PLANE_RADAR_LAT 48.4284f
+#endif
+#ifndef PLANE_RADAR_LON
+    #define PLANE_RADAR_LON -123.3656f
+#endif
+#ifndef PLANE_RADAR_RANGE_INDEX
+    #define PLANE_RADAR_RANGE_INDEX 1
+#endif
+#ifndef PLANE_RADAR_FETCH_INTERVAL_SEC
+    #define PLANE_RADAR_FETCH_INTERVAL_SEC 3
+#endif
+#ifndef PLANE_RADAR_CYCLE_DELAY
+    #define PLANE_RADAR_CYCLE_DELAY 180
+#endif

--- a/firmware/src/core/utils/MainHelper.cpp
+++ b/firmware/src/core/utils/MainHelper.cpp
@@ -137,10 +137,28 @@ void MainHelper::checkButtons() {
 }
 
 void MainHelper::checkCycleWidgets() {
-    if (s_widgetSet && s_widgetCycleDelay > 0 && (s_widgetCycleDelayPrev == 0 || (millis() - s_widgetCycleDelayPrev) >= s_widgetCycleDelay * 1000)) {
-        s_widgetSet->next();
-        s_widgetCycleDelayPrev = millis();
+    if (!s_widgetSet) {
+        return;
     }
+
+    Widget *current = s_widgetSet->getCurrent();
+    unsigned long cycleDelayMs = 0;
+    if (current != nullptr) {
+        const unsigned long perWidgetDelay = current->getWidgetCyclePageDelayMs();
+        cycleDelayMs = perWidgetDelay > 0 ? perWidgetDelay : static_cast<unsigned long>(s_widgetCycleDelay) * 1000UL;
+    } else {
+        cycleDelayMs = static_cast<unsigned long>(s_widgetCycleDelay) * 1000UL;
+    }
+
+    if (cycleDelayMs <= 0) {
+        return;
+    }
+    if (s_widgetCycleDelayPrev != 0 && (millis() - s_widgetCycleDelayPrev) < cycleDelayMs) {
+        return;
+    }
+
+    s_widgetSet->next();
+    s_widgetCycleDelayPrev = millis();
 }
 
 // Handle simulated button state

--- a/firmware/src/core/widget/Widget.h
+++ b/firmware/src/core/widget/Widget.h
@@ -18,6 +18,8 @@ public:
     virtual void draw(bool force = false) = 0;
     virtual void buttonPressed(uint8_t buttonId, ButtonState state) = 0;
     virtual String getName() = 0;
+    // Non-zero overrides global widget cycle delay while this widget is active.
+    virtual unsigned long getWidgetCyclePageDelayMs() const { return 0; }
 
     WidgetTimer &addDrawRefreshFrequency(TimeFrequency frequency);
     WidgetTimer &addUpdateRefreshFrequency(TimeFrequency frequency);

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -9,6 +9,9 @@
 #include "weatherwidget/WeatherWidget.h"
 #include "webdatawidget/WebDataWidget.h"
 #include "wifiwidget/WifiWidget.h"
+#if INCLUDE_PLANE_RADAR != WIDGET_DISABLED
+    #include "planeradarwidget/PlaneRadarWidget.h"
+#endif
 #include <ArduinoLog.h>
 
 TFT_eSPI tft = TFT_eSPI();
@@ -50,6 +53,9 @@ void addWidgets() {
 #endif
 #if INCLUDE_MATRIXSCREEN != WIDGET_DISABLED
     widgetSet->add(new MatrixWidget(*sm, *config));
+#endif
+#if INCLUDE_PLANE_RADAR != WIDGET_DISABLED
+    widgetSet->add(new PlaneRadarWidget(*sm, *config));
 #endif
 }
 

--- a/firmware/src/widgets/planeradarwidget/AdsbClient.cpp
+++ b/firmware/src/widgets/planeradarwidget/AdsbClient.cpp
@@ -1,0 +1,241 @@
+#include "AdsbClient.h"
+
+#include <ArduinoJson.h>
+#include <HTTPClient.h>
+#include <WiFiClientSecure.h>
+
+#include <cmath>
+#include <cstring>
+
+namespace {
+
+constexpr char kApiBase[] = "https://opendata.adsb.fi/api/v3/lat/";
+constexpr float kKmPerNm = 1.852f;
+constexpr int kConnectAttemptMs = 200;
+constexpr unsigned long kRequestTimeoutMs = 10000;
+
+AdsbClient::Aircraft s_aircraft[AdsbClient::kMaxAircraft];
+size_t s_aircraftCount = 0;
+
+int performGetWithRetry(HTTPClient &http) {
+    http.setConnectTimeout(kConnectAttemptMs);
+    const unsigned long deadline = millis() + kRequestTimeoutMs;
+    while (millis() < deadline) {
+        const int code = http.GET();
+        if (code > 0) {
+            return code;
+        }
+        if (code != HTTPC_ERROR_CONNECTION_REFUSED && code != HTTPC_ERROR_NOT_CONNECTED) {
+            return code;
+        }
+        delay(5);
+    }
+    return HTTPC_ERROR_READ_TIMEOUT;
+}
+
+bool readJsonFloat(const JsonObject &obj, const char *key, float *out) {
+    if (obj[key].is<float>() || obj[key].is<double>() || obj[key].is<int>()) {
+        *out = obj[key].as<float>();
+        return true;
+    }
+    return false;
+}
+
+float pickNoseHeading(const JsonObject &plane) {
+    float v = 0.0f;
+    if (readJsonFloat(plane, "true_heading", &v)) {
+        return v;
+    }
+    if (readJsonFloat(plane, "mag_heading", &v)) {
+        return v;
+    }
+    if (readJsonFloat(plane, "track", &v)) {
+        return v;
+    }
+    if (readJsonFloat(plane, "dir", &v)) {
+        return v;
+    }
+    return 0.0f;
+}
+
+float pickTrackHeading(const JsonObject &plane) {
+    float v = 0.0f;
+    if (readJsonFloat(plane, "track", &v)) {
+        return v;
+    }
+    if (readJsonFloat(plane, "true_heading", &v)) {
+        return v;
+    }
+    if (readJsonFloat(plane, "mag_heading", &v)) {
+        return v;
+    }
+    if (readJsonFloat(plane, "dir", &v)) {
+        return v;
+    }
+    return 0.0f;
+}
+
+float pickGroundSpeed(const JsonObject &plane) {
+    float v = 0.0f;
+    if (readJsonFloat(plane, "gs", &v)) {
+        return v;
+    }
+    if (readJsonFloat(plane, "tas", &v)) {
+        return v;
+    }
+    if (readJsonFloat(plane, "ias", &v)) {
+        return v;
+    }
+    return 0.0f;
+}
+
+bool isOnGround(const JsonObject &plane) {
+    if (!plane["alt_baro"].is<const char *>()) {
+        return false;
+    }
+    return strcmp(plane["alt_baro"].as<const char *>(), "ground") == 0;
+}
+
+void copyJsonStringTrimmed(const JsonObject &obj, const char *key, char *out, size_t outLen) {
+    out[0] = '\0';
+    if (outLen == 0 || !obj[key].is<const char *>()) {
+        return;
+    }
+    const char *s = obj[key].as<const char *>();
+    size_t n = strnlen(s, outLen - 1);
+    while (n > 0 && s[n - 1] == ' ') {
+        --n;
+    }
+    memcpy(out, s, n);
+    out[n] = '\0';
+}
+
+void formatAltitudeTag(const JsonObject &plane, char *out, size_t outLen) {
+    out[0] = '\0';
+    if (outLen == 0) {
+        return;
+    }
+
+    if (plane["alt_baro"].is<const char *>()) {
+        const char *s = plane["alt_baro"].as<const char *>();
+        if (strcmp(s, "ground") == 0) {
+            strncpy(out, "GND", outLen - 1);
+            out[outLen - 1] = '\0';
+            return;
+        }
+    }
+
+    float alt = 0.0f;
+    if (readJsonFloat(plane, "alt_baro", &alt) || readJsonFloat(plane, "alt_geom", &alt)) {
+        snprintf(out, outLen, "%d ft", static_cast<int>(lroundf(alt)));
+    }
+}
+
+void fillTagFields(AdsbClient::Aircraft *ac, const JsonObject &plane) {
+    copyJsonStringTrimmed(plane, "flight", ac->callsign, sizeof(ac->callsign));
+    if (ac->callsign[0] == '\0') {
+        copyJsonStringTrimmed(plane, "hex", ac->callsign, sizeof(ac->callsign));
+    }
+    copyJsonStringTrimmed(plane, "t", ac->type, sizeof(ac->type));
+    copyJsonStringTrimmed(plane, "desc", ac->desc, sizeof(ac->desc));
+    formatAltitudeTag(plane, ac->alt, sizeof(ac->alt));
+
+    ac->dbFlags = 0;
+    if (plane["dbFlags"].is<int>() || plane["dbFlags"].is<unsigned int>()) {
+        ac->dbFlags = static_cast<uint8_t>(plane["dbFlags"].as<unsigned>() & 0xFF);
+    }
+
+    ac->baroRateFpm = 0;
+    ac->hasBaroRate = false;
+    float baroRate = 0.0f;
+    if (readJsonFloat(plane, "baro_rate", &baroRate)) {
+        ac->baroRateFpm = static_cast<int16_t>(lroundf(baroRate));
+        ac->hasBaroRate = true;
+    } else if (readJsonFloat(plane, "geom_rate", &baroRate)) {
+        ac->baroRateFpm = static_cast<int16_t>(lroundf(baroRate));
+        ac->hasBaroRate = true;
+    }
+}
+
+} // namespace
+
+bool AdsbClient::fetchUpdate(double centerLat, double centerLon, float fetchRadiusKm) {
+    const float distNm = fetchRadiusKm / kKmPerNm;
+
+    String url = kApiBase;
+    url += String(centerLat, 6);
+    url += "/lon/";
+    url += String(centerLon, 6);
+    url += "/dist/";
+    url += String(distNm, 1);
+
+    WiFiClientSecure client;
+    client.setInsecure();
+
+    HTTPClient http;
+    if (!http.begin(client, url)) {
+        Serial.println("adsb: http.begin failed");
+        return false;
+    }
+
+    http.setTimeout(kRequestTimeoutMs);
+    const int code = performGetWithRetry(http);
+    if (code != HTTP_CODE_OK) {
+        Serial.printf("adsb: HTTP %d\n", code);
+        http.end();
+        return false;
+    }
+
+    const String payload = http.getString();
+    http.end();
+    if (payload.length() == 0) {
+        Serial.println("adsb: empty response");
+        return false;
+    }
+
+    JsonDocument doc;
+    const DeserializationError err = deserializeJson(doc, payload);
+    if (err) {
+        Serial.printf("adsb: JSON parse error: %s\n", err.c_str());
+        return false;
+    }
+
+    JsonArray ac = doc["ac"].as<JsonArray>();
+    if (ac.isNull()) {
+        s_aircraftCount = 0;
+        return true;
+    }
+
+    size_t n = 0;
+    for (JsonObject plane : ac) {
+        if (n >= kMaxAircraft) {
+            break;
+        }
+        if (!plane["lat"].is<float>() || !plane["lon"].is<float>()) {
+            continue;
+        }
+        if (isOnGround(plane)) {
+            continue;
+        }
+
+        s_aircraft[n].lat = plane["lat"].as<float>();
+        s_aircraft[n].lon = plane["lon"].as<float>();
+        s_aircraft[n].noseDeg = pickNoseHeading(plane);
+        s_aircraft[n].trackDeg = pickTrackHeading(plane);
+        s_aircraft[n].gsKnots = pickGroundSpeed(plane);
+        fillTagFields(&s_aircraft[n], plane);
+        ++n;
+    }
+
+    s_aircraftCount = n;
+    Serial.printf("adsb: %u aircraft\n", static_cast<unsigned>(n));
+    return true;
+}
+
+size_t AdsbClient::aircraftCount() {
+    return s_aircraftCount;
+}
+
+const AdsbClient::Aircraft *AdsbClient::aircraftList() {
+    return s_aircraft;
+}

--- a/firmware/src/widgets/planeradarwidget/AdsbClient.h
+++ b/firmware/src/widgets/planeradarwidget/AdsbClient.h
@@ -1,0 +1,31 @@
+#ifndef ADSB_CLIENT_H
+#define ADSB_CLIENT_H
+
+#include <cstddef>
+#include <cstdint>
+
+class AdsbClient {
+public:
+    struct Aircraft {
+        float lat;
+        float lon;
+        float noseDeg;
+        float trackDeg;
+        float gsKnots;
+        char callsign[9];
+        char type[5];
+        char desc[36];
+        char alt[12];
+        uint8_t dbFlags = 0;
+        int16_t baroRateFpm = 0;
+        bool hasBaroRate = false;
+    };
+
+    static constexpr size_t kMaxAircraft = 64;
+
+    static bool fetchUpdate(double centerLat, double centerLon, float fetchRadiusKm);
+    static size_t aircraftCount();
+    static const Aircraft *aircraftList();
+};
+
+#endif

--- a/firmware/src/widgets/planeradarwidget/PlaneRadarWidget.cpp
+++ b/firmware/src/widgets/planeradarwidget/PlaneRadarWidget.cpp
@@ -1,0 +1,732 @@
+#include "PlaneRadarWidget.h"
+
+#include "config_helper.h"
+
+#include <cmath>
+#include <cstring>
+
+namespace {
+
+constexpr uint16_t rgb565Color(uint8_t r, uint8_t g, uint8_t b) {
+    return static_cast<uint16_t>(((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3));
+}
+
+constexpr int kSize = 240;
+constexpr int kCenterX = ScreenCenterX;
+constexpr int kCenterY = ScreenCenterY;
+constexpr int kGridOuterRadius = 107;
+constexpr int kRingCount = 4;
+constexpr int kCenterDotRadius = 2;
+constexpr int kAircraftNoseLenPx = 9;
+constexpr int kAircraftTailLenPx = 4;
+constexpr int kAircraftTailHalfPx = 5;
+constexpr int kAircraftInsideRingInsetPx = kAircraftNoseLenPx + kAircraftTailHalfPx + 1;
+constexpr int kBeyondRingDotRadiusPx = 5;
+constexpr int kBeyondRingScreenMarginPx = 2;
+constexpr float kAircraftTrackHorizonSec = 60.0f;
+constexpr int kAircraftSpeedLineMinPx = 2;
+constexpr float kAircraftTrackRefOuterKm = 13.3f;
+constexpr float kAircraftTrackLengthScale = 1.5f / 5.0f;
+constexpr float kKmPerDeg = 111.0f;
+constexpr float kKmPerMile = 1.609344f;
+constexpr char kPrefsNamespace[] = "planeradar";
+constexpr char kPrefsRangeKey[] = "rangeIdx";
+
+const uint16_t kColorBackground = rgb565Color(4, 10, 28);
+const uint16_t kColorGrid = rgb565Color(16, 100, 32);
+const uint16_t kColorLabel = TFT_WHITE;
+const uint16_t kColorAircraft = TFT_YELLOW;
+const uint16_t kColorTrack = 0xF81F;
+const uint16_t kColorType = rgb565Color(255, 200, 0);
+const uint16_t kColorAlt = rgb565Color(90, 200, 255);
+const uint16_t kColorMil = TFT_RED;
+const uint16_t kColorInteresting = rgb565Color(0, 200, 255);
+const uint16_t kColorPia = 0xF81F;
+const uint16_t kColorLadd = TFT_DARKGREY;
+
+constexpr float kKtToMph = 1.15078f;
+constexpr uint8_t kDbFlagMilitary = 1;
+constexpr uint8_t kDbFlagInteresting = 2;
+constexpr uint8_t kDbFlagPia = 4;
+constexpr uint8_t kDbFlagLadd = 8;
+
+enum class MovementHint : int8_t {
+    Unknown = 0,
+    Arriving,
+    Departing,
+};
+
+const uint16_t kColorArriving = rgb565Color(80, 220, 120);
+const uint16_t kColorDeparting = rgb565Color(255, 180, 60);
+
+MovementHint classifyMovement(const AdsbClient::Aircraft &plane) {
+    if (plane.gsKnots < 40.0f || !plane.hasBaroRate) {
+        return MovementHint::Unknown;
+    }
+    if (plane.baroRateFpm <= -250) {
+        return MovementHint::Arriving;
+    }
+    if (plane.baroRateFpm >= 250) {
+        return MovementHint::Departing;
+    }
+    return MovementHint::Unknown;
+}
+
+const char *movementLabel(MovementHint hint) {
+    switch (hint) {
+    case MovementHint::Arriving:
+        return "Arriving";
+    case MovementHint::Departing:
+        return "Departing";
+    default:
+        return nullptr;
+    }
+}
+
+uint16_t movementColor(MovementHint hint) {
+    switch (hint) {
+    case MovementHint::Arriving:
+        return kColorArriving;
+    case MovementHint::Departing:
+        return kColorDeparting;
+    default:
+        return kColorLabel;
+    }
+}
+
+bool hasSpecialDbFlags(uint8_t flags) {
+    return (flags & (kDbFlagMilitary | kDbFlagInteresting | kDbFlagPia | kDbFlagLadd)) != 0;
+}
+
+uint16_t dbFlagsOutlineColor(uint8_t flags) {
+    if (flags & kDbFlagMilitary) {
+        return kColorMil;
+    }
+    if (flags & kDbFlagPia) {
+        return kColorPia;
+    }
+    if (flags & kDbFlagLadd) {
+        return kColorLadd;
+    }
+    if (flags & kDbFlagInteresting) {
+        return kColorInteresting;
+    }
+    return kColorLabel;
+}
+
+void formatDbFlagsLabel(uint8_t flags, char *buf, size_t len) {
+    buf[0] = '\0';
+    if (len == 0 || !hasSpecialDbFlags(flags)) {
+        return;
+    }
+
+    bool first = true;
+    auto append = [&](const char *label) {
+        if (!first) {
+            strncat(buf, " · ", len - strlen(buf) - 1);
+        }
+        strncat(buf, label, len - strlen(buf) - 1);
+        first = false;
+    };
+
+    if (flags & kDbFlagMilitary) {
+        append("MILITARY");
+    }
+    if (flags & kDbFlagInteresting) {
+        append("INTERESTING");
+    }
+    if (flags & kDbFlagPia) {
+        append("PIA");
+    }
+    if (flags & kDbFlagLadd) {
+        append("LADD");
+    }
+}
+
+void drawSpecialOrbOutline(ScreenManager &sm, uint16_t color) {
+    sm.drawCircle(kCenterX, kCenterY, 118, color);
+    sm.drawCircle(kCenterX, kCenterY, 117, color);
+}
+
+int knotsToMph(float knots) {
+    return static_cast<int>(lroundf(knots * kKtToMph));
+}
+
+int distSqFromCenter(int x, int y) {
+    const int dx = x - kCenterX;
+    const int dy = y - kCenterY;
+    return dx * dx + dy * dy;
+}
+
+void drawThickLine(ScreenManager &sm, int x0, int y0, int x1, int y1, uint16_t color) {
+    sm.drawLine(x0, y0, x1, y1, color);
+    sm.drawLine(x0 + 1, y0, x1 + 1, y1, color);
+}
+
+void drawGridRing(ScreenManager &sm, int cx, int cy, int r, uint16_t color) {
+    if (r <= 0) {
+        return;
+    }
+    for (int i = 0; i < 2 && r - i > 0; ++i) {
+        sm.drawCircle(cx, cy, r - i, color);
+    }
+}
+
+void drawCardinal(ScreenManager &sm, const char *text, int x, int y, uint8_t datum) {
+    sm.setLegacyTextColor(kColorLabel, kColorBackground);
+    sm.setLegacyTextDatum(datum);
+    sm.setLegacyTextSize(1);
+    sm.drawLegacyString(text, x, y, 2);
+}
+
+float innerRingMaxKm(float outerKm) {
+    return outerKm * (static_cast<float>(kGridOuterRadius - kAircraftInsideRingInsetPx) /
+                      static_cast<float>(kGridOuterRadius));
+}
+
+void offsetKmFromCenter(double centerLat, double centerLon, float lat, float lon, float *dxKm, float *dyKm,
+                        float *distKm) {
+    *dxKm = static_cast<float>(lon - centerLon) * kKmPerDeg;
+    *dyKm = static_cast<float>(lat - centerLat) * kKmPerDeg;
+    *distKm = sqrtf((*dxKm) * (*dxKm) + (*dyKm) * (*dyKm));
+}
+
+void latLonToScreen(double centerLat, double centerLon, float outerKm, float lat, float lon, int *outX,
+                    int *outY) {
+    const float pxPerKm = static_cast<float>(kGridOuterRadius) / outerKm;
+    float dxKm = 0.0f;
+    float dyKm = 0.0f;
+    float distKm = 0.0f;
+    offsetKmFromCenter(centerLat, centerLon, lat, lon, &dxKm, &dyKm, &distKm);
+    *outX = kCenterX + static_cast<int>(lroundf(dxKm * pxPerKm));
+    *outY = kCenterY - static_cast<int>(lroundf(dyKm * pxPerKm));
+}
+
+bool beyondRingEdgeDot(double centerLat, double centerLon, float outerKm, float lat, float lon, int *outX,
+                       int *outY) {
+    float dxKm = 0.0f;
+    float dyKm = 0.0f;
+    float distKm = 0.0f;
+    offsetKmFromCenter(centerLat, centerLon, lat, lon, &dxKm, &dyKm, &distKm);
+    if (distKm < 0.01f || distKm <= innerRingMaxKm(outerKm)) {
+        return false;
+    }
+
+    const int rimR = kCenterX - kBeyondRingScreenMarginPx;
+    const float angleRad = atan2f(dxKm, dyKm);
+    *outX = kCenterX + static_cast<int>(lroundf(sinf(angleRad) * rimR));
+    *outY = kCenterY - static_cast<int>(lroundf(cosf(angleRad) * rimR));
+    return true;
+}
+
+void noseTip(int cx, int cy, float headingDeg, int *tipX, int *tipY) {
+    const float rad = headingDeg * DEG_TO_RAD;
+    *tipX = cx + static_cast<int>(lroundf(sinf(rad) * kAircraftNoseLenPx));
+    *tipY = cy - static_cast<int>(lroundf(cosf(rad) * kAircraftNoseLenPx));
+}
+
+void clipPointToOuterRing(int x0, int y0, int *x1, int *y1) {
+    const int maxRSq = kGridOuterRadius * kGridOuterRadius;
+    if (distSqFromCenter(*x1, *y1) <= maxRSq) {
+        return;
+    }
+
+    const int dx = *x1 - x0;
+    const int dy = *y1 - y0;
+    float t = 1.0f;
+    for (int step = 0; step < 20; ++step) {
+        const int px = x0 + static_cast<int>(lroundf(dx * t));
+        const int py = y0 + static_cast<int>(lroundf(dy * t));
+        if (distSqFromCenter(px, py) <= maxRSq) {
+            *x1 = px;
+            *y1 = py;
+            return;
+        }
+        t -= 0.05f;
+        if (t <= 0.0f) {
+            *x1 = x0;
+            *y1 = y0;
+            return;
+        }
+    }
+}
+
+int speedLineLengthPx(float gsKnots) {
+    if (gsKnots <= 0.0f) {
+        return 0;
+    }
+    constexpr float kKmPerKnotPerHorizon = 1.852f * kAircraftTrackHorizonSec / 3600.0f;
+    const float px = gsKnots * kKmPerKnotPerHorizon * kGridOuterRadius / kAircraftTrackRefOuterKm *
+                     kAircraftTrackLengthScale;
+    const int len = static_cast<int>(px + 0.5f);
+    return len < kAircraftSpeedLineMinPx ? kAircraftSpeedLineMinPx : len;
+}
+
+void drawHeadingTriangle(ScreenManager &sm, int cx, int cy, float headingDeg, uint16_t color) {
+    const float rad = headingDeg * DEG_TO_RAD;
+    const float sinH = sinf(rad);
+    const float cosH = cosf(rad);
+
+    int tipX = 0;
+    int tipY = 0;
+    noseTip(cx, cy, headingDeg, &tipX, &tipY);
+
+    const int baseX = cx - static_cast<int>(lroundf(sinH * kAircraftTailLenPx));
+    const int baseY = cy + static_cast<int>(lroundf(cosH * kAircraftTailLenPx));
+    const int wingX = static_cast<int>(lroundf(cosH * kAircraftTailHalfPx));
+    const int wingY = static_cast<int>(lroundf(sinH * kAircraftTailHalfPx));
+
+    sm.fillTriangle(tipX, tipY, baseX + wingX, baseY + wingY, baseX - wingX, baseY - wingY, color);
+}
+
+void drawSpeedVector(ScreenManager &sm, int cx, int cy, float headingDeg, float trackDeg, float gsKnots,
+                     uint16_t color) {
+    const int len = speedLineLengthPx(gsKnots);
+    if (len <= 0) {
+        return;
+    }
+
+    int tipX = 0;
+    int tipY = 0;
+    noseTip(cx, cy, headingDeg, &tipX, &tipY);
+
+    const float rad = trackDeg * DEG_TO_RAD;
+    int ex = tipX + static_cast<int>(lroundf(sinf(rad) * len));
+    int ey = tipY - static_cast<int>(lroundf(cosf(rad) * len));
+    clipPointToOuterRing(tipX, tipY, &ex, &ey);
+    if (ex == tipX && ey == tipY) {
+        return;
+    }
+    drawThickLine(sm, tipX, tipY, ex, ey, color);
+}
+
+struct DrawItem {
+    size_t index = 0;
+    int x = 0;
+    int y = 0;
+    int distSq = 0;
+    bool isRim = false;
+};
+
+void sortDrawItemsFarFirst(DrawItem *items, size_t count) {
+    for (size_t i = 1; i < count; ++i) {
+        const DrawItem key = items[i];
+        size_t j = i;
+        while (j > 0 && items[j - 1].distSq < key.distSq) {
+            items[j] = items[j - 1];
+            --j;
+        }
+        items[j] = key;
+    }
+}
+
+} // namespace
+
+const PlaneRadarWidget::RangePreset PlaneRadarWidget::kRangePresets[] = {
+    {5.0f, 5.0f * 4.0f / 3.0f},
+    {10.0f, 10.0f * 4.0f / 3.0f},
+    {15.0f, 15.0f * 4.0f / 3.0f},
+    {25.0f, 25.0f * 4.0f / 3.0f},
+};
+
+PlaneRadarWidget::PlaneRadarWidget(ScreenManager &manager, ConfigManager &config)
+    : Widget(manager, config),
+      m_configLat(PLANE_RADAR_LAT),
+      m_configLon(PLANE_RADAR_LON),
+      m_fetchIntervalSec(PLANE_RADAR_FETCH_INTERVAL_SEC),
+      m_cycleDelaySec(PLANE_RADAR_CYCLE_DELAY),
+#ifdef PLANE_RADAR_RANGE_INDEX
+      m_rangeIndex(PLANE_RADAR_RANGE_INDEX),
+#else
+      m_rangeIndex(1),
+#endif
+#ifdef PLANE_RADAR_UNITS_METRIC
+      m_useMetric(true)
+#else
+      m_useMetric(false)
+#endif
+{
+    m_enabled = (INCLUDE_PLANE_RADAR == WIDGET_ON);
+    m_config.addConfigBool("PlaneRadarWidget", "planeEnabled", &m_enabled, t_enableWidget);
+    m_config.addConfigFloat("PlaneRadarWidget", "planeLat", &m_configLat, "Radar center latitude");
+    m_config.addConfigFloat("PlaneRadarWidget", "planeLon", &m_configLon, "Radar center longitude");
+    m_config.addConfigInt("PlaneRadarWidget", "planeFetchSec", &m_fetchIntervalSec, "ADS-B poll interval (seconds)", true);
+    m_config.addConfigInt("PlaneRadarWidget", "planeCycleSec", &m_cycleDelaySec, "Seconds on Plane Radar before carousel advances", true);
+    m_config.addConfigBool("PlaneRadarWidget", "planeUnitsMetric", &m_useMetric, "Use metric units on range label", true);
+
+    for (int i = 0; i < kDetailSlots; ++i) {
+        m_lastDetail[i].occupied = false;
+        m_lastDetail[i].callsign[0] = '\0';
+    }
+}
+
+unsigned long PlaneRadarWidget::getWidgetCyclePageDelayMs() const {
+    return static_cast<unsigned long>(m_cycleDelaySec) * 1000UL;
+}
+
+void PlaneRadarWidget::setup() {
+    m_fetchPrev = 0;
+    m_dataChanged = true;
+    m_hasData = false;
+    m_sortedCount = 0;
+    m_routeFetchSlot = 0;
+    m_lastAircraftCount = UINT_MAX;
+    RouteClient::clearCache();
+    for (int i = 0; i < kDetailSlots; ++i) {
+        m_lastDetail[i].occupied = false;
+        m_lastDetail[i].route[0] = '\0';
+    }
+
+    if (m_prefs.begin(kPrefsNamespace, true)) {
+        const uint8_t saved = m_prefs.getUChar(kPrefsRangeKey, m_rangeIndex);
+        m_rangeIndex = saved < kRangePresetCount ? saved : m_rangeIndex;
+        m_prefs.end();
+    }
+}
+
+void PlaneRadarWidget::saveRangeIndex() {
+    if (m_prefs.begin(kPrefsNamespace, false)) {
+        m_prefs.putUChar(kPrefsRangeKey, m_rangeIndex);
+        m_prefs.end();
+    }
+}
+
+void PlaneRadarWidget::cycleRange() {
+    m_rangeIndex = static_cast<uint8_t>((m_rangeIndex + 1) % kRangePresetCount);
+    saveRangeIndex();
+    m_fetchPrev = 0;
+    m_dataChanged = true;
+}
+
+const PlaneRadarWidget::RangePreset &PlaneRadarWidget::currentRange() const {
+    return kRangePresets[m_rangeIndex];
+}
+
+float PlaneRadarWidget::fetchRadiusKm() const {
+    const float outerKm = currentRange().outerKm;
+    const float screenRPx = static_cast<float>(kCenterX - kBeyondRingScreenMarginPx);
+    return outerKm * (screenRPx / static_cast<float>(kGridOuterRadius));
+}
+
+void PlaneRadarWidget::formatRangeLabel(char *buf, size_t len) const {
+    const float ring3Km = currentRange().ring3Km;
+    if (m_useMetric) {
+        snprintf(buf, len, "%dkm", static_cast<int>(lroundf(ring3Km)));
+    } else {
+        snprintf(buf, len, "%dmi", static_cast<int>(lroundf(ring3Km / kKmPerMile)));
+    }
+}
+
+float PlaneRadarWidget::distanceKm(float lat, float lon) const {
+    float dxKm = 0.0f;
+    float dyKm = 0.0f;
+    float distKm = 0.0f;
+    offsetKmFromCenter(m_configLat, m_configLon, lat, lon, &dxKm, &dyKm, &distKm);
+    return distKm;
+}
+
+void PlaneRadarWidget::rebuildSortedList() {
+    m_sortedCount = 0;
+    const size_t n = AdsbClient::aircraftCount();
+    const AdsbClient::Aircraft *planes = AdsbClient::aircraftList();
+
+    for (size_t i = 0; i < n && m_sortedCount < AdsbClient::kMaxAircraft; ++i) {
+        m_sorted[m_sortedCount].index = i;
+        m_sorted[m_sortedCount].distKm = distanceKm(planes[i].lat, planes[i].lon);
+        ++m_sortedCount;
+    }
+
+    for (size_t i = 1; i < m_sortedCount; ++i) {
+        const SortedEntry key = m_sorted[i];
+        size_t j = i;
+        while (j > 0 && m_sorted[j - 1].distKm > key.distKm) {
+            m_sorted[j] = m_sorted[j - 1];
+            --j;
+        }
+        m_sorted[j] = key;
+    }
+}
+
+void PlaneRadarWidget::update(bool force) {
+    if (!force && m_fetchPrev != 0 && (millis() - m_fetchPrev) < static_cast<unsigned long>(m_fetchIntervalSec) * 1000UL) {
+        return;
+    }
+
+    setBusy(true);
+    bool ok = false;
+    if (force) {
+        int retry = 0;
+        while (!(ok = AdsbClient::fetchUpdate(m_configLat, m_configLon, fetchRadiusKm())) && retry++ < MAX_RETRIES) {
+        }
+    } else {
+        ok = AdsbClient::fetchUpdate(m_configLat, m_configLon, fetchRadiusKm());
+    }
+    setBusy(false);
+
+    m_fetchPrev = millis();
+    if (ok) {
+        rebuildSortedList();
+        m_hasData = true;
+        m_dataChanged = true;
+        refreshRouteData();
+    }
+}
+
+void PlaneRadarWidget::refreshRouteData() {
+    const int slots = m_sortedCount < static_cast<size_t>(kDetailSlots) ? static_cast<int>(m_sortedCount)
+                                                                        : kDetailSlots;
+    if (slots <= 0) {
+        return;
+    }
+
+    const char *callsigns[kDetailSlots];
+    for (int i = 0; i < slots; ++i) {
+        callsigns[i] = AdsbClient::aircraftList()[m_sorted[i].index].callsign;
+    }
+
+    setBusy(true);
+    const bool fetched = RouteClient::prefetchOne(callsigns, static_cast<size_t>(slots), &m_routeFetchSlot);
+    setBusy(false);
+
+    if (fetched) {
+        m_dataChanged = true;
+    }
+}
+
+void PlaneRadarWidget::draw(bool force) {
+    m_manager.setFont(DEFAULT_FONT);
+    if (!force && !m_dataChanged) {
+        return;
+    }
+
+    if (!m_hasData) {
+        if (force) {
+            drawLoadingRadar(0);
+        }
+        m_dataChanged = false;
+        return;
+    }
+
+    drawStaticRadarGrid(0);
+    drawAircraftLayer();
+    drawChangedDetails();
+    m_dataChanged = false;
+}
+
+void PlaneRadarWidget::drawLoadingRadar(int screenIndex) {
+    m_manager.selectScreen(screenIndex);
+    m_manager.fillScreen(kColorBackground);
+    m_manager.drawCentreString("Plane Radar", kCenterX, kCenterY - 20, 22);
+    m_manager.drawCentreString("Loading...", kCenterX, kCenterY + 20, 18);
+}
+
+void PlaneRadarWidget::drawStaticRadarGrid(int screenIndex) {
+    m_manager.selectScreen(screenIndex);
+    m_manager.fillScreen(kColorBackground);
+
+    drawGridRing(m_manager, kCenterX, kCenterY, kGridOuterRadius, kColorGrid);
+    for (int i = 1; i < kRingCount; ++i) {
+        const int r = (kGridOuterRadius * i) / kRingCount;
+        drawGridRing(m_manager, kCenterX, kCenterY, r, kColorGrid);
+    }
+
+    drawThickLine(m_manager, kCenterX, kCenterY - kGridOuterRadius, kCenterX, kCenterY + kGridOuterRadius,
+                  kColorGrid);
+    drawThickLine(m_manager, kCenterX - kGridOuterRadius, kCenterY, kCenterX + kGridOuterRadius, kCenterY,
+                  kColorGrid);
+
+    m_manager.fillCircle(kCenterX, kCenterY, kCenterDotRadius, kColorLabel);
+
+    drawCardinal(m_manager, "N", kCenterX, 2, TC_DATUM);
+    drawCardinal(m_manager, "S", kCenterX, kSize - 2, BC_DATUM);
+    drawCardinal(m_manager, "W", 2, kCenterY, ML_DATUM);
+    drawCardinal(m_manager, "E", kSize - 2, kCenterY, MR_DATUM);
+
+    char rangeLabel[12];
+    formatRangeLabel(rangeLabel, sizeof(rangeLabel));
+    m_manager.setLegacyTextColor(kColorGrid, kColorBackground);
+    m_manager.setLegacyTextDatum(MR_DATUM);
+    m_manager.drawLegacyString(rangeLabel, kCenterX + kGridOuterRadius - 6, kCenterY, 2);
+
+    m_lastAircraftCount = UINT_MAX;
+    updateCountLabel(static_cast<unsigned>(AdsbClient::aircraftCount()));
+}
+
+void PlaneRadarWidget::drawAircraftLayer() {
+    m_manager.selectScreen(0);
+
+    const float outerKm = currentRange().outerKm;
+    const float maxDistKm = innerRingMaxKm(outerKm);
+    const size_t n = AdsbClient::aircraftCount();
+    const AdsbClient::Aircraft *planes = AdsbClient::aircraftList();
+
+    DrawItem items[AdsbClient::kMaxAircraft];
+    size_t drawCount = 0;
+
+    for (size_t i = 0; i < n; ++i) {
+        float dxKm = 0.0f;
+        float dyKm = 0.0f;
+        float distKm = 0.0f;
+        offsetKmFromCenter(m_configLat, m_configLon, planes[i].lat, planes[i].lon, &dxKm, &dyKm, &distKm);
+
+        if (distKm <= maxDistKm) {
+            int x = 0;
+            int y = 0;
+            latLonToScreen(m_configLat, m_configLon, outerKm, planes[i].lat, planes[i].lon, &x, &y);
+            items[drawCount].index = i;
+            items[drawCount].x = x;
+            items[drawCount].y = y;
+            items[drawCount].distSq = distSqFromCenter(x, y);
+            items[drawCount].isRim = false;
+            ++drawCount;
+            continue;
+        }
+
+        int dotX = 0;
+        int dotY = 0;
+        if (beyondRingEdgeDot(m_configLat, m_configLon, outerKm, planes[i].lat, planes[i].lon, &dotX, &dotY)) {
+            m_manager.fillCircle(dotX, dotY, kBeyondRingDotRadiusPx, kColorAircraft);
+        }
+    }
+
+    sortDrawItemsFarFirst(items, drawCount);
+    for (size_t d = 0; d < drawCount; ++d) {
+        const size_t i = items[d].index;
+        drawSpeedVector(m_manager, items[d].x, items[d].y, planes[i].noseDeg, planes[i].trackDeg,
+                        planes[i].gsKnots, kColorTrack);
+    }
+    for (size_t d = 0; d < drawCount; ++d) {
+        const size_t i = items[d].index;
+        drawHeadingTriangle(m_manager, items[d].x, items[d].y, planes[i].noseDeg, kColorAircraft);
+    }
+
+    updateCountLabel(static_cast<unsigned>(n));
+}
+
+void PlaneRadarWidget::updateCountLabel(unsigned count) {
+    if (count == m_lastAircraftCount) {
+        return;
+    }
+    m_lastAircraftCount = count;
+
+    char countLabel[24];
+    snprintf(countLabel, sizeof(countLabel), "%u aircraft", count);
+    m_manager.fillRect(kCenterX - 52, kSize - 24, 104, 16, kColorBackground);
+    m_manager.setLegacyTextColor(kColorLabel, kColorBackground);
+    m_manager.setLegacyTextDatum(TC_DATUM);
+    m_manager.drawLegacyString(countLabel, kCenterX, kSize - 18, 2);
+}
+
+void PlaneRadarWidget::drawAircraftDetail(int screenIndex, int rank) {
+    m_manager.selectScreen(screenIndex);
+    m_manager.fillScreen(kColorBackground);
+
+    if (rank < 0 || rank >= static_cast<int>(m_sortedCount)) {
+        drawEmptyDetail(screenIndex);
+        return;
+    }
+
+    const AdsbClient::Aircraft &plane = AdsbClient::aircraftList()[m_sorted[rank].index];
+
+    if (hasSpecialDbFlags(plane.dbFlags)) {
+        drawSpecialOrbOutline(m_manager, dbFlagsOutlineColor(plane.dbFlags));
+    }
+
+    String callsign = plane.callsign[0] != '\0' ? String(plane.callsign) : String("Unknown");
+
+    String description;
+    if (plane.desc[0] != '\0') {
+        description = String(plane.desc);
+    } else if (plane.type[0] != '\0') {
+        description = String(plane.type);
+    } else {
+        description = "Unknown";
+    }
+
+    String speed;
+    if (plane.gsKnots > 0.0f) {
+        speed = String(knotsToMph(plane.gsKnots)) + " mph";
+    } else {
+        speed = "— mph";
+    }
+
+    String altitude = plane.alt[0] != '\0' ? String(plane.alt) : String("—");
+
+    char route[56];
+    RouteClient::formatRoute(plane.callsign, route, sizeof(route));
+
+    m_manager.drawString(callsign, kCenterX, 32, 22, Align::MiddleCenter, kColorLabel, kColorBackground);
+    m_manager.drawFittedString(description, kCenterX, 68, 200, 32, Align::MiddleCenter);
+    if (route[0] != '\0') {
+        m_manager.drawFittedString(String(route), kCenterX, 102, 200, 28, Align::MiddleCenter);
+    }
+    m_manager.drawString(speed, kCenterX, 132, 18, Align::MiddleCenter, kColorLabel, kColorBackground);
+    m_manager.drawString(altitude, kCenterX, 164, 18, Align::MiddleCenter, kColorAlt, kColorBackground);
+
+    if (hasSpecialDbFlags(plane.dbFlags)) {
+        char flagLabel[48];
+        formatDbFlagsLabel(plane.dbFlags, flagLabel, sizeof(flagLabel));
+        m_manager.drawString(String(flagLabel), kCenterX, 204, 14, Align::MiddleCenter,
+                             dbFlagsOutlineColor(plane.dbFlags), kColorBackground);
+    } else {
+        const MovementHint movement = classifyMovement(plane);
+        const char *label = movementLabel(movement);
+        if (label != nullptr) {
+            m_manager.drawString(String(label), kCenterX, 204, 14, Align::MiddleCenter, movementColor(movement),
+                                 kColorBackground);
+        }
+    }
+}
+
+void PlaneRadarWidget::drawEmptyDetail(int screenIndex) {
+    m_manager.selectScreen(screenIndex);
+    m_manager.fillScreen(kColorBackground);
+    m_manager.drawCentreString("No aircraft", kCenterX, kCenterY, 18);
+}
+
+void PlaneRadarWidget::drawChangedDetails() {
+    for (int slot = 0; slot < kDetailSlots; ++slot) {
+        DetailSnapshot next{};
+        if (slot < static_cast<int>(m_sortedCount)) {
+            const AdsbClient::Aircraft &plane = AdsbClient::aircraftList()[m_sorted[slot].index];
+            strncpy(next.callsign, plane.callsign, sizeof(next.callsign) - 1);
+            strncpy(next.desc, plane.desc[0] != '\0' ? plane.desc : plane.type, sizeof(next.desc) - 1);
+            RouteClient::formatRoute(plane.callsign, next.route, sizeof(next.route));
+            strncpy(next.alt, plane.alt, sizeof(next.alt) - 1);
+            next.speedMph = knotsToMph(plane.gsKnots);
+            next.dbFlags = plane.dbFlags;
+            next.movement = static_cast<int8_t>(classifyMovement(plane));
+            next.occupied = true;
+        }
+
+        const DetailSnapshot &prev = m_lastDetail[slot];
+        const bool changed = next.occupied != prev.occupied ||
+                             strncmp(next.callsign, prev.callsign, sizeof(next.callsign)) != 0 ||
+                             strncmp(next.desc, prev.desc, sizeof(next.desc)) != 0 ||
+                             strncmp(next.route, prev.route, sizeof(next.route)) != 0 ||
+                             strncmp(next.alt, prev.alt, sizeof(next.alt)) != 0 ||
+                             next.speedMph != prev.speedMph || next.dbFlags != prev.dbFlags ||
+                             next.movement != prev.movement;
+
+        if (!changed) {
+            continue;
+        }
+
+        if (next.occupied) {
+            drawAircraftDetail(slot + 1, slot);
+        } else {
+            drawEmptyDetail(slot + 1);
+        }
+        m_lastDetail[slot] = next;
+    }
+}
+
+void PlaneRadarWidget::buttonPressed(uint8_t buttonId, ButtonState state) {
+    if (buttonId == BUTTON_OK && state == BTN_SHORT) {
+        cycleRange();
+    }
+}
+
+String PlaneRadarWidget::getName() {
+    return "Plane Radar";
+}

--- a/firmware/src/widgets/planeradarwidget/PlaneRadarWidget.cpp
+++ b/firmware/src/widgets/planeradarwidget/PlaneRadarWidget.cpp
@@ -380,6 +380,7 @@ void PlaneRadarWidget::setup() {
         m_lastDetail[i].occupied = false;
         m_lastDetail[i].route[0] = '\0';
         m_slotCallsign[i][0] = '\0';
+        m_detailDrawn[i] = false;
     }
 
     if (m_prefs.begin(kPrefsNamespace, true)) {
@@ -527,7 +528,7 @@ void PlaneRadarWidget::draw(bool force) {
     }
 
     drawAircraftLayer();
-    drawChangedDetails();
+    drawChangedDetails(force);
     m_dataChanged = false;
 }
 
@@ -798,7 +799,7 @@ void PlaneRadarWidget::drawEmptyDetail(int screenIndex) {
     m_manager.drawString("No aircraft", kCenterX, kCenterY, 18, Align::MiddleCenter, kColorLabel, kColorBackground);
 }
 
-void PlaneRadarWidget::drawChangedDetails() {
+void PlaneRadarWidget::drawChangedDetails(bool force) {
     for (int slot = 0; slot < kDetailSlots; ++slot) {
         const int rank = resolveDetailRank(slot);
 
@@ -827,7 +828,7 @@ void PlaneRadarWidget::drawChangedDetails() {
                              strncmp(next.alt, prev.alt, sizeof(next.alt)) != 0 || speedChanged ||
                              next.dbFlags != prev.dbFlags || movementLabelChanged;
 
-        if (!changed) {
+        if (!changed && !force && m_detailDrawn[slot]) {
             continue;
         }
 
@@ -837,6 +838,7 @@ void PlaneRadarWidget::drawChangedDetails() {
             drawEmptyDetail(slot + 1);
         }
         m_lastDetail[slot] = next;
+        m_detailDrawn[slot] = true;
     }
 }
 

--- a/firmware/src/widgets/planeradarwidget/PlaneRadarWidget.cpp
+++ b/firmware/src/widgets/planeradarwidget/PlaneRadarWidget.cpp
@@ -45,6 +45,7 @@ const uint16_t kColorPia = 0xF81F;
 const uint16_t kColorLadd = TFT_DARKGREY;
 
 constexpr float kKtToMph = 1.15078f;
+constexpr int kSpeedRedrawThresholdMph = 2;
 constexpr uint8_t kDbFlagMilitary = 1;
 constexpr uint8_t kDbFlagInteresting = 2;
 constexpr uint8_t kDbFlagPia = 4;
@@ -357,6 +358,7 @@ PlaneRadarWidget::PlaneRadarWidget(ScreenManager &manager, ConfigManager &config
     for (int i = 0; i < kDetailSlots; ++i) {
         m_lastDetail[i].occupied = false;
         m_lastDetail[i].callsign[0] = '\0';
+        m_slotCallsign[i][0] = '\0';
     }
 }
 
@@ -371,10 +373,13 @@ void PlaneRadarWidget::setup() {
     m_sortedCount = 0;
     m_routeFetchSlot = 0;
     m_lastAircraftCount = UINT_MAX;
+    m_fullRedrawNeeded = true;
+    m_lastDrawnCount = 0;
     RouteClient::clearCache();
     for (int i = 0; i < kDetailSlots; ++i) {
         m_lastDetail[i].occupied = false;
         m_lastDetail[i].route[0] = '\0';
+        m_slotCallsign[i][0] = '\0';
     }
 
     if (m_prefs.begin(kPrefsNamespace, true)) {
@@ -396,6 +401,10 @@ void PlaneRadarWidget::cycleRange() {
     saveRangeIndex();
     m_fetchPrev = 0;
     m_dataChanged = true;
+    m_fullRedrawNeeded = true;
+    for (int i = 0; i < kDetailSlots; ++i) {
+        m_slotCallsign[i][0] = '\0';
+    }
 }
 
 const PlaneRadarWidget::RangePreset &PlaneRadarWidget::currentRange() const {
@@ -473,19 +482,20 @@ void PlaneRadarWidget::update(bool force) {
 }
 
 void PlaneRadarWidget::refreshRouteData() {
-    const int slots = m_sortedCount < static_cast<size_t>(kDetailSlots) ? static_cast<int>(m_sortedCount)
-                                                                        : kDetailSlots;
-    if (slots <= 0) {
+    const char *callsigns[kDetailSlots];
+    size_t count = 0;
+    for (int i = 0; i < kDetailSlots; ++i) {
+        const int rank = resolveDetailRank(i);
+        if (rank >= 0) {
+            callsigns[count++] = AdsbClient::aircraftList()[m_sorted[rank].index].callsign;
+        }
+    }
+    if (count == 0) {
         return;
     }
 
-    const char *callsigns[kDetailSlots];
-    for (int i = 0; i < slots; ++i) {
-        callsigns[i] = AdsbClient::aircraftList()[m_sorted[i].index].callsign;
-    }
-
     setBusy(true);
-    const bool fetched = RouteClient::prefetchOne(callsigns, static_cast<size_t>(slots), &m_routeFetchSlot);
+    const bool fetched = RouteClient::prefetchOne(callsigns, count, &m_routeFetchSlot);
     setBusy(false);
 
     if (fetched) {
@@ -502,12 +512,20 @@ void PlaneRadarWidget::draw(bool force) {
     if (!m_hasData) {
         if (force) {
             drawLoadingRadar(0);
+            m_fullRedrawNeeded = true;
         }
         m_dataChanged = false;
         return;
     }
 
-    drawStaticRadarGrid(0);
+    if (force || m_fullRedrawNeeded) {
+        drawStaticRadarGrid(0, true);
+        m_fullRedrawNeeded = false;
+    } else {
+        eraseOldPlanes();
+        drawStaticRadarGrid(0, false);
+    }
+
     drawAircraftLayer();
     drawChangedDetails();
     m_dataChanged = false;
@@ -516,13 +534,17 @@ void PlaneRadarWidget::draw(bool force) {
 void PlaneRadarWidget::drawLoadingRadar(int screenIndex) {
     m_manager.selectScreen(screenIndex);
     m_manager.fillScreen(kColorBackground);
-    m_manager.drawCentreString("Plane Radar", kCenterX, kCenterY - 20, 22);
-    m_manager.drawCentreString("Loading...", kCenterX, kCenterY + 20, 18);
+    m_manager.drawString("Plane Radar", kCenterX, kCenterY - 20, 22, Align::MiddleCenter, kColorLabel,
+                         kColorBackground);
+    m_manager.drawString("Loading...", kCenterX, kCenterY + 20, 18, Align::MiddleCenter, kColorLabel,
+                         kColorBackground);
 }
 
-void PlaneRadarWidget::drawStaticRadarGrid(int screenIndex) {
+void PlaneRadarWidget::drawStaticRadarGrid(int screenIndex, bool fullRedraw) {
     m_manager.selectScreen(screenIndex);
-    m_manager.fillScreen(kColorBackground);
+    if (fullRedraw) {
+        m_manager.fillScreen(kColorBackground);
+    }
 
     drawGridRing(m_manager, kCenterX, kCenterY, kGridOuterRadius, kColorGrid);
     for (int i = 1; i < kRingCount; ++i) {
@@ -548,8 +570,24 @@ void PlaneRadarWidget::drawStaticRadarGrid(int screenIndex) {
     m_manager.setLegacyTextDatum(MR_DATUM);
     m_manager.drawLegacyString(rangeLabel, kCenterX + kGridOuterRadius - 6, kCenterY, 2);
 
-    m_lastAircraftCount = UINT_MAX;
-    updateCountLabel(static_cast<unsigned>(AdsbClient::aircraftCount()));
+    if (fullRedraw) {
+        m_lastAircraftCount = UINT_MAX;
+        updateCountLabel(static_cast<unsigned>(AdsbClient::aircraftCount()));
+    }
+}
+
+void PlaneRadarWidget::eraseOldPlanes() {
+    m_manager.selectScreen(0);
+    for (size_t i = 0; i < m_lastDrawnCount; ++i) {
+        const DrawnPlane &p = m_lastDrawnPlanes[i];
+        if (p.isDot) {
+            m_manager.fillCircle(p.x, p.y, kBeyondRingDotRadiusPx, kColorBackground);
+        } else {
+            drawSpeedVector(m_manager, p.x, p.y, p.headingDeg, p.trackDeg, p.gsKnots, kColorBackground);
+            drawHeadingTriangle(m_manager, p.x, p.y, p.headingDeg, kColorBackground);
+        }
+    }
+    m_lastDrawnCount = 0;
 }
 
 void PlaneRadarWidget::drawAircraftLayer() {
@@ -562,6 +600,7 @@ void PlaneRadarWidget::drawAircraftLayer() {
 
     DrawItem items[AdsbClient::kMaxAircraft];
     size_t drawCount = 0;
+    m_lastDrawnCount = 0;
 
     for (size_t i = 0; i < n; ++i) {
         float dxKm = 0.0f;
@@ -579,6 +618,10 @@ void PlaneRadarWidget::drawAircraftLayer() {
             items[drawCount].distSq = distSqFromCenter(x, y);
             items[drawCount].isRim = false;
             ++drawCount;
+            
+            if (m_lastDrawnCount < AdsbClient::kMaxAircraft) {
+                m_lastDrawnPlanes[m_lastDrawnCount++] = {x, y, planes[i].noseDeg, planes[i].trackDeg, planes[i].gsKnots, false};
+            }
             continue;
         }
 
@@ -586,6 +629,9 @@ void PlaneRadarWidget::drawAircraftLayer() {
         int dotY = 0;
         if (beyondRingEdgeDot(m_configLat, m_configLon, outerKm, planes[i].lat, planes[i].lon, &dotX, &dotY)) {
             m_manager.fillCircle(dotX, dotY, kBeyondRingDotRadiusPx, kColorAircraft);
+            if (m_lastDrawnCount < AdsbClient::kMaxAircraft) {
+                m_lastDrawnPlanes[m_lastDrawnCount++] = {dotX, dotY, 0.0f, 0.0f, 0.0f, true};
+            }
         }
     }
 
@@ -617,9 +663,9 @@ void PlaneRadarWidget::updateCountLabel(unsigned count) {
     m_manager.drawLegacyString(countLabel, kCenterX, kSize - 18, 2);
 }
 
-void PlaneRadarWidget::drawAircraftDetail(int screenIndex, int rank) {
+void PlaneRadarWidget::updateAircraftDetail(int screenIndex, int rank, const DetailSnapshot &prev,
+                                            const DetailSnapshot &next) {
     m_manager.selectScreen(screenIndex);
-    m_manager.fillScreen(kColorBackground);
 
     if (rank < 0 || rank >= static_cast<int>(m_sortedCount)) {
         drawEmptyDetail(screenIndex);
@@ -627,93 +673,166 @@ void PlaneRadarWidget::drawAircraftDetail(int screenIndex, int rank) {
     }
 
     const AdsbClient::Aircraft &plane = AdsbClient::aircraftList()[m_sorted[rank].index];
+    const bool newPlane =
+        !prev.occupied || strncmp(prev.callsign, next.callsign, sizeof(prev.callsign)) != 0;
 
-    if (hasSpecialDbFlags(plane.dbFlags)) {
-        drawSpecialOrbOutline(m_manager, dbFlagsOutlineColor(plane.dbFlags));
+    if (newPlane) {
+        m_manager.fillScreen(kColorBackground);
     }
 
-    String callsign = plane.callsign[0] != '\0' ? String(plane.callsign) : String("Unknown");
-
-    String description;
-    if (plane.desc[0] != '\0') {
-        description = String(plane.desc);
-    } else if (plane.type[0] != '\0') {
-        description = String(plane.type);
-    } else {
-        description = "Unknown";
-    }
-
-    String speed;
-    if (plane.gsKnots > 0.0f) {
-        speed = String(knotsToMph(plane.gsKnots)) + " mph";
-    } else {
-        speed = "— mph";
-    }
-
-    String altitude = plane.alt[0] != '\0' ? String(plane.alt) : String("—");
-
-    char route[56];
-    RouteClient::formatRoute(plane.callsign, route, sizeof(route));
-
-    m_manager.drawString(callsign, kCenterX, 32, 22, Align::MiddleCenter, kColorLabel, kColorBackground);
-    m_manager.drawFittedString(description, kCenterX, 68, 200, 32, Align::MiddleCenter);
-    if (route[0] != '\0') {
-        m_manager.drawFittedString(String(route), kCenterX, 102, 200, 28, Align::MiddleCenter);
-    }
-    m_manager.drawString(speed, kCenterX, 132, 18, Align::MiddleCenter, kColorLabel, kColorBackground);
-    m_manager.drawString(altitude, kCenterX, 164, 18, Align::MiddleCenter, kColorAlt, kColorBackground);
-
-    if (hasSpecialDbFlags(plane.dbFlags)) {
-        char flagLabel[48];
-        formatDbFlagsLabel(plane.dbFlags, flagLabel, sizeof(flagLabel));
-        m_manager.drawString(String(flagLabel), kCenterX, 204, 14, Align::MiddleCenter,
-                             dbFlagsOutlineColor(plane.dbFlags), kColorBackground);
-    } else {
-        const MovementHint movement = classifyMovement(plane);
-        const char *label = movementLabel(movement);
-        if (label != nullptr) {
-            m_manager.drawString(String(label), kCenterX, 204, 14, Align::MiddleCenter, movementColor(movement),
-                                 kColorBackground);
+    if (newPlane || next.dbFlags != prev.dbFlags) {
+        if (hasSpecialDbFlags(plane.dbFlags)) {
+            drawSpecialOrbOutline(m_manager, dbFlagsOutlineColor(plane.dbFlags));
+        } else {
+            drawSpecialOrbOutline(m_manager, kColorBackground);
         }
     }
+
+    if (newPlane || strncmp(next.callsign, prev.callsign, sizeof(next.callsign)) != 0) {
+        m_manager.fillRect(0, 14, kSize, 36, kColorBackground);
+        const String callsign = next.callsign[0] != '\0' ? String(next.callsign) : String("Unknown");
+        m_manager.drawString(callsign, kCenterX, 32, 22, Align::MiddleCenter, kColorLabel, kColorBackground);
+    }
+
+    if (newPlane || strncmp(next.desc, prev.desc, sizeof(next.desc)) != 0) {
+        m_manager.fillRect(0, 50, kSize, 40, kColorBackground);
+        m_manager.setFontColor(kColorLabel, kColorBackground);
+        const String description = next.desc[0] != '\0' ? String(next.desc) : String("Unknown");
+        m_manager.drawFittedString(description, kCenterX, 68, 200, 32, Align::MiddleCenter);
+    }
+
+    if (newPlane || strncmp(next.route, prev.route, sizeof(next.route)) != 0) {
+        m_manager.fillRect(0, 88, kSize, 32, kColorBackground);
+        if (next.route[0] != '\0') {
+            m_manager.setFontColor(kColorLabel, kColorBackground);
+            m_manager.drawFittedString(String(next.route), kCenterX, 102, 200, 28, Align::MiddleCenter);
+        }
+    }
+
+    if (newPlane || abs(next.speedMph - prev.speedMph) >= kSpeedRedrawThresholdMph) {
+        m_manager.fillRect(0, 118, kSize, 30, kColorBackground);
+        const String speed = next.speedMph > 0 ? String(next.speedMph) + " mph" : String("— mph");
+        m_manager.drawString(speed, kCenterX, 132, 18, Align::MiddleCenter, kColorLabel, kColorBackground);
+    }
+
+    if (newPlane || strncmp(next.alt, prev.alt, sizeof(next.alt)) != 0) {
+        m_manager.fillRect(0, 150, kSize, 38, kColorBackground);
+        const String altitude = next.alt[0] != '\0' ? String(next.alt) : String("—");
+        m_manager.drawString(altitude, kCenterX, 164, 18, Align::MiddleCenter, kColorAlt, kColorBackground);
+    }
+
+    const MovementHint movement = static_cast<MovementHint>(next.movement);
+    const char *movementLabelText = movementLabel(movement);
+    const MovementHint prevMovement = static_cast<MovementHint>(prev.movement);
+    const char *prevMovementLabelText = movementLabel(prevMovement);
+    const bool movementLabelChanged = (movementLabelText == nullptr) != (prevMovementLabelText == nullptr) ||
+                                      (movementLabelText != nullptr && prevMovementLabelText != nullptr &&
+                                       strcmp(movementLabelText, prevMovementLabelText) != 0);
+
+    if (newPlane || next.dbFlags != prev.dbFlags || movementLabelChanged) {
+        m_manager.fillRect(0, 188, kSize, 32, kColorBackground);
+        if (hasSpecialDbFlags(plane.dbFlags)) {
+            char flagLabel[48];
+            formatDbFlagsLabel(plane.dbFlags, flagLabel, sizeof(flagLabel));
+            m_manager.drawString(String(flagLabel), kCenterX, 204, 14, Align::MiddleCenter,
+                                 dbFlagsOutlineColor(plane.dbFlags), kColorBackground);
+        } else if (movementLabelText != nullptr) {
+            m_manager.drawString(String(movementLabelText), kCenterX, 204, 14, Align::MiddleCenter,
+                                 movementColor(movement), kColorBackground);
+        }
+    }
+}
+
+void PlaneRadarWidget::buildDetailSnapshot(int rank, DetailSnapshot *out) const {
+    *out = {};
+    if (rank < 0 || rank >= static_cast<int>(m_sortedCount)) {
+        return;
+    }
+
+    const AdsbClient::Aircraft &plane = AdsbClient::aircraftList()[m_sorted[rank].index];
+    strncpy(out->callsign, plane.callsign, sizeof(out->callsign) - 1);
+    strncpy(out->desc, plane.desc[0] != '\0' ? plane.desc : plane.type, sizeof(out->desc) - 1);
+    RouteClient::formatRoute(plane.callsign, out->route, sizeof(out->route));
+    strncpy(out->alt, plane.alt, sizeof(out->alt) - 1);
+    out->speedMph = knotsToMph(plane.gsKnots);
+    out->dbFlags = plane.dbFlags;
+    out->movement = static_cast<int8_t>(classifyMovement(plane));
+    out->occupied = true;
+}
+
+int PlaneRadarWidget::resolveDetailRank(int slot) const {
+    if (m_sortedCount == 0) {
+        return -1;
+    }
+
+    if (m_slotCallsign[slot][0] != '\0') {
+        for (size_t i = 0; i < m_sortedCount; ++i) {
+            const char *callsign = AdsbClient::aircraftList()[m_sorted[i].index].callsign;
+            if (strncmp(callsign, m_slotCallsign[slot], sizeof(m_slotCallsign[slot])) == 0) {
+                return static_cast<int>(i);
+            }
+        }
+    }
+
+    for (size_t i = 0; i < m_sortedCount; ++i) {
+        const char *callsign = AdsbClient::aircraftList()[m_sorted[i].index].callsign;
+        bool used = false;
+        for (int s = 0; s < kDetailSlots; ++s) {
+            if (s != slot && m_slotCallsign[s][0] != '\0' &&
+                strncmp(m_slotCallsign[s], callsign, sizeof(m_slotCallsign[s])) == 0) {
+                used = true;
+                break;
+            }
+        }
+        if (!used) {
+            return static_cast<int>(i);
+        }
+    }
+
+    return -1;
 }
 
 void PlaneRadarWidget::drawEmptyDetail(int screenIndex) {
     m_manager.selectScreen(screenIndex);
     m_manager.fillScreen(kColorBackground);
-    m_manager.drawCentreString("No aircraft", kCenterX, kCenterY, 18);
+    m_manager.drawString("No aircraft", kCenterX, kCenterY, 18, Align::MiddleCenter, kColorLabel, kColorBackground);
 }
 
 void PlaneRadarWidget::drawChangedDetails() {
     for (int slot = 0; slot < kDetailSlots; ++slot) {
+        const int rank = resolveDetailRank(slot);
+
         DetailSnapshot next{};
-        if (slot < static_cast<int>(m_sortedCount)) {
-            const AdsbClient::Aircraft &plane = AdsbClient::aircraftList()[m_sorted[slot].index];
-            strncpy(next.callsign, plane.callsign, sizeof(next.callsign) - 1);
-            strncpy(next.desc, plane.desc[0] != '\0' ? plane.desc : plane.type, sizeof(next.desc) - 1);
-            RouteClient::formatRoute(plane.callsign, next.route, sizeof(next.route));
-            strncpy(next.alt, plane.alt, sizeof(next.alt) - 1);
-            next.speedMph = knotsToMph(plane.gsKnots);
-            next.dbFlags = plane.dbFlags;
-            next.movement = static_cast<int8_t>(classifyMovement(plane));
-            next.occupied = true;
+        if (rank >= 0) {
+            buildDetailSnapshot(rank, &next);
+            strncpy(m_slotCallsign[slot], next.callsign, sizeof(m_slotCallsign[slot]) - 1);
+        } else {
+            m_slotCallsign[slot][0] = '\0';
         }
 
         const DetailSnapshot &prev = m_lastDetail[slot];
+        const MovementHint movement = static_cast<MovementHint>(next.movement);
+        const char *movementLabelText = next.occupied ? movementLabel(movement) : nullptr;
+        const MovementHint prevMovement = static_cast<MovementHint>(prev.movement);
+        const char *prevMovementLabelText = prev.occupied ? movementLabel(prevMovement) : nullptr;
+        const bool movementLabelChanged = (movementLabelText == nullptr) != (prevMovementLabelText == nullptr) ||
+                                          (movementLabelText != nullptr && prevMovementLabelText != nullptr &&
+                                           strcmp(movementLabelText, prevMovementLabelText) != 0);
+        const bool speedChanged =
+            next.occupied && prev.occupied && abs(next.speedMph - prev.speedMph) >= kSpeedRedrawThresholdMph;
         const bool changed = next.occupied != prev.occupied ||
                              strncmp(next.callsign, prev.callsign, sizeof(next.callsign)) != 0 ||
                              strncmp(next.desc, prev.desc, sizeof(next.desc)) != 0 ||
                              strncmp(next.route, prev.route, sizeof(next.route)) != 0 ||
-                             strncmp(next.alt, prev.alt, sizeof(next.alt)) != 0 ||
-                             next.speedMph != prev.speedMph || next.dbFlags != prev.dbFlags ||
-                             next.movement != prev.movement;
+                             strncmp(next.alt, prev.alt, sizeof(next.alt)) != 0 || speedChanged ||
+                             next.dbFlags != prev.dbFlags || movementLabelChanged;
 
         if (!changed) {
             continue;
         }
 
         if (next.occupied) {
-            drawAircraftDetail(slot + 1, slot);
+            updateAircraftDetail(slot + 1, rank, prev, next);
         } else {
             drawEmptyDetail(slot + 1);
         }

--- a/firmware/src/widgets/planeradarwidget/PlaneRadarWidget.h
+++ b/firmware/src/widgets/planeradarwidget/PlaneRadarWidget.h
@@ -1,0 +1,85 @@
+#ifndef PLANE_RADAR_WIDGET_H
+#define PLANE_RADAR_WIDGET_H
+
+#include "AdsbClient.h"
+#include "RouteClient.h"
+#include "Widget.h"
+
+#include <Preferences.h>
+
+class PlaneRadarWidget : public Widget {
+public:
+    PlaneRadarWidget(ScreenManager &manager, ConfigManager &config);
+    void setup() override;
+    void update(bool force = false) override;
+    void draw(bool force = false) override;
+    void buttonPressed(uint8_t buttonId, ButtonState state) override;
+    String getName() override;
+    unsigned long getWidgetCyclePageDelayMs() const override;
+
+private:
+    struct RangePreset {
+        float ring3Km;
+        float outerKm;
+    };
+
+    struct SortedEntry {
+        size_t index;
+        float distKm;
+    };
+
+    struct DetailSnapshot {
+        char callsign[9];
+        char desc[36];
+        char route[56];
+        char alt[12];
+        int speedMph;
+        uint8_t dbFlags;
+        int8_t movement;
+        bool occupied;
+    };
+
+    static const RangePreset kRangePresets[];
+    static constexpr size_t kRangePresetCount = 4;
+    static constexpr int kDetailSlots = NUM_SCREENS - 1;
+
+    void cycleRange();
+    void saveRangeIndex();
+    const RangePreset &currentRange() const;
+    float fetchRadiusKm() const;
+    void formatRangeLabel(char *buf, size_t len) const;
+    void rebuildSortedList();
+    float distanceKm(float lat, float lon) const;
+    void refreshRouteData();
+
+    void drawStaticRadarGrid(int screenIndex);
+    void drawLoadingRadar(int screenIndex);
+    void drawAircraftLayer();
+    void updateCountLabel(unsigned count);
+
+    void drawAircraftDetail(int screenIndex, int rank);
+    void drawEmptyDetail(int screenIndex);
+    void drawChangedDetails();
+
+    float m_configLat;
+    float m_configLon;
+    int m_fetchIntervalSec;
+    int m_cycleDelaySec;
+    bool m_useMetric;
+
+    uint8_t m_rangeIndex;
+    unsigned long m_fetchPrev = 0;
+    bool m_dataChanged = true;
+    bool m_hasData = false;
+
+    unsigned m_lastAircraftCount = UINT_MAX;
+
+    SortedEntry m_sorted[AdsbClient::kMaxAircraft];
+    size_t m_sortedCount = 0;
+    size_t m_routeFetchSlot = 0;
+    DetailSnapshot m_lastDetail[kDetailSlots];
+
+    Preferences m_prefs;
+};
+
+#endif

--- a/firmware/src/widgets/planeradarwidget/PlaneRadarWidget.h
+++ b/firmware/src/widgets/planeradarwidget/PlaneRadarWidget.h
@@ -39,6 +39,15 @@ private:
         bool occupied;
     };
 
+    struct DrawnPlane {
+        int x;
+        int y;
+        float headingDeg;
+        float trackDeg;
+        float gsKnots;
+        bool isDot;
+    };
+
     static const RangePreset kRangePresets[];
     static constexpr size_t kRangePresetCount = 4;
     static constexpr int kDetailSlots = NUM_SCREENS - 1;
@@ -51,13 +60,16 @@ private:
     void rebuildSortedList();
     float distanceKm(float lat, float lon) const;
     void refreshRouteData();
+    int resolveDetailRank(int slot) const;
+    void buildDetailSnapshot(int rank, DetailSnapshot *out) const;
 
-    void drawStaticRadarGrid(int screenIndex);
+    void drawStaticRadarGrid(int screenIndex, bool fullRedraw);
     void drawLoadingRadar(int screenIndex);
     void drawAircraftLayer();
+    void eraseOldPlanes();
     void updateCountLabel(unsigned count);
 
-    void drawAircraftDetail(int screenIndex, int rank);
+    void updateAircraftDetail(int screenIndex, int rank, const DetailSnapshot &prev, const DetailSnapshot &next);
     void drawEmptyDetail(int screenIndex);
     void drawChangedDetails();
 
@@ -78,6 +90,11 @@ private:
     size_t m_sortedCount = 0;
     size_t m_routeFetchSlot = 0;
     DetailSnapshot m_lastDetail[kDetailSlots];
+    char m_slotCallsign[kDetailSlots][9];
+
+    DrawnPlane m_lastDrawnPlanes[AdsbClient::kMaxAircraft];
+    size_t m_lastDrawnCount = 0;
+    bool m_fullRedrawNeeded = true;
 
     Preferences m_prefs;
 };

--- a/firmware/src/widgets/planeradarwidget/PlaneRadarWidget.h
+++ b/firmware/src/widgets/planeradarwidget/PlaneRadarWidget.h
@@ -71,7 +71,7 @@ private:
 
     void updateAircraftDetail(int screenIndex, int rank, const DetailSnapshot &prev, const DetailSnapshot &next);
     void drawEmptyDetail(int screenIndex);
-    void drawChangedDetails();
+    void drawChangedDetails(bool force = false);
 
     float m_configLat;
     float m_configLon;
@@ -91,6 +91,7 @@ private:
     size_t m_routeFetchSlot = 0;
     DetailSnapshot m_lastDetail[kDetailSlots];
     char m_slotCallsign[kDetailSlots][9];
+    bool m_detailDrawn[kDetailSlots] = {};
 
     DrawnPlane m_lastDrawnPlanes[AdsbClient::kMaxAircraft];
     size_t m_lastDrawnCount = 0;

--- a/firmware/src/widgets/planeradarwidget/RouteClient.cpp
+++ b/firmware/src/widgets/planeradarwidget/RouteClient.cpp
@@ -1,0 +1,311 @@
+#include "RouteClient.h"
+
+#include <ArduinoJson.h>
+#include <HTTPClient.h>
+#include <WiFiClientSecure.h>
+
+#include <cstring>
+
+namespace {
+
+constexpr char kApiBase[] = "https://api.adsbdb.com/v0/callsign/";
+constexpr int kConnectAttemptMs = 200;
+constexpr unsigned long kRequestTimeoutMs = 8000;
+constexpr unsigned long kMinFetchIntervalMs = 4000;
+constexpr size_t kCacheSize = 12;
+
+enum class CacheState : uint8_t {
+    Empty = 0,
+    Found,
+    NotFound,
+};
+
+struct CacheEntry {
+    char callsign[9];
+    char originLabel[28];
+    char destLabel[28];
+    CacheState state = CacheState::Empty;
+};
+
+CacheEntry s_cache[kCacheSize];
+unsigned long s_lastFetchMs = 0;
+size_t s_evictIndex = 0;
+
+void normalizeCallsign(const char *in, char *out, size_t outLen) {
+    out[0] = '\0';
+    if (outLen == 0 || in == nullptr) {
+        return;
+    }
+
+    size_t n = strnlen(in, outLen - 1);
+    while (n > 0 && in[n - 1] == ' ') {
+        --n;
+    }
+    size_t start = 0;
+    while (start < n && in[start] == ' ') {
+        ++start;
+    }
+    n -= start;
+    if (n >= outLen) {
+        n = outLen - 1;
+    }
+    for (size_t i = 0; i < n; ++i) {
+        char c = in[start + i];
+        if (c >= 'a' && c <= 'z') {
+            c = static_cast<char>(c - 'a' + 'A');
+        }
+        out[i] = c;
+    }
+    out[n] = '\0';
+}
+
+bool callsignLikelyRouteable(const char *callsign) {
+    if (callsign[0] == '\0') {
+        return false;
+    }
+    bool hasLetter = false;
+    for (size_t i = 0; callsign[i] != '\0'; ++i) {
+        const char c = callsign[i];
+        if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
+            hasLetter = true;
+        }
+    }
+    return hasLetter;
+}
+
+CacheEntry *findEntry(const char *callsign) {
+    for (size_t i = 0; i < kCacheSize; ++i) {
+        if (s_cache[i].state != CacheState::Empty && strcmp(s_cache[i].callsign, callsign) == 0) {
+            return &s_cache[i];
+        }
+    }
+    return nullptr;
+}
+
+CacheEntry *allocEntry(const char *callsign) {
+    CacheEntry *existing = findEntry(callsign);
+    if (existing != nullptr) {
+        return existing;
+    }
+
+    for (size_t i = 0; i < kCacheSize; ++i) {
+        if (s_cache[i].state == CacheState::Empty) {
+            return &s_cache[i];
+        }
+    }
+
+    CacheEntry *slot = &s_cache[s_evictIndex];
+    s_evictIndex = (s_evictIndex + 1) % kCacheSize;
+    slot->state = CacheState::Empty;
+    slot->callsign[0] = '\0';
+    slot->originLabel[0] = '\0';
+    slot->destLabel[0] = '\0';
+    return slot;
+}
+
+void formatAirportLabel(const JsonObject &airport, char *out, size_t outLen) {
+    out[0] = '\0';
+    if (outLen == 0 || airport.isNull()) {
+        return;
+    }
+
+    const char *city =
+        airport["municipality"].is<const char *>() ? airport["municipality"].as<const char *>() : nullptr;
+    const char *country =
+        airport["country_iso_name"].is<const char *>() ? airport["country_iso_name"].as<const char *>() : nullptr;
+    const char *iata =
+        airport["iata_code"].is<const char *>() ? airport["iata_code"].as<const char *>() : nullptr;
+
+    if (city != nullptr && city[0] != '\0') {
+        if (country != nullptr && country[0] != '\0' && strcmp(country, "US") != 0) {
+            snprintf(out, outLen, "%s, %s", city, country);
+        } else {
+            strncpy(out, city, outLen - 1);
+            out[outLen - 1] = '\0';
+        }
+        return;
+    }
+
+    if (iata != nullptr && iata[0] != '\0') {
+        strncpy(out, iata, outLen - 1);
+        out[outLen - 1] = '\0';
+    }
+}
+
+int performGet(HTTPClient &http) {
+    http.setConnectTimeout(kConnectAttemptMs);
+    const unsigned long deadline = millis() + kRequestTimeoutMs;
+    while (millis() < deadline) {
+        const int code = http.GET();
+        if (code > 0) {
+            return code;
+        }
+        if (code != HTTPC_ERROR_CONNECTION_REFUSED && code != HTTPC_ERROR_NOT_CONNECTED) {
+            return code;
+        }
+        delay(5);
+    }
+    return HTTPC_ERROR_READ_TIMEOUT;
+}
+
+bool fetchRouteFromApi(const char *callsign, char *originLabel, size_t originLen, char *destLabel,
+                       size_t destLen) {
+    originLabel[0] = '\0';
+    destLabel[0] = '\0';
+
+    String url = kApiBase;
+    url += callsign;
+
+    WiFiClientSecure client;
+    client.setInsecure();
+
+    HTTPClient http;
+    if (!http.begin(client, url)) {
+        Serial.println("route: http.begin failed");
+        return false;
+    }
+
+    http.setTimeout(kRequestTimeoutMs);
+    const int code = performGet(http);
+    if (code == HTTP_CODE_NOT_FOUND) {
+        http.end();
+        return true;
+    }
+    if (code != HTTP_CODE_OK) {
+        Serial.printf("route: HTTP %d for %s\n", code, callsign);
+        http.end();
+        return false;
+    }
+
+    const String payload = http.getString();
+    http.end();
+    if (payload.length() == 0) {
+        return false;
+    }
+
+    JsonDocument doc;
+    const DeserializationError err = deserializeJson(doc, payload);
+    if (err) {
+        Serial.printf("route: JSON error: %s\n", err.c_str());
+        return false;
+    }
+
+    JsonObject route = doc["response"]["flightroute"].as<JsonObject>();
+    if (route.isNull()) {
+        return true;
+    }
+
+    formatAirportLabel(route["origin"].as<JsonObject>(), originLabel, originLen);
+    formatAirportLabel(route["destination"].as<JsonObject>(), destLabel, destLen);
+    return true;
+}
+
+} // namespace
+
+void RouteClient::clearCache() {
+    for (size_t i = 0; i < kCacheSize; ++i) {
+        s_cache[i].state = CacheState::Empty;
+        s_cache[i].callsign[0] = '\0';
+        s_cache[i].originLabel[0] = '\0';
+        s_cache[i].destLabel[0] = '\0';
+    }
+    s_lastFetchMs = 0;
+    s_evictIndex = 0;
+}
+
+bool RouteClient::isCached(const char *callsign) {
+    char key[9];
+    normalizeCallsign(callsign, key, sizeof(key));
+    if (!callsignLikelyRouteable(key)) {
+        return true;
+    }
+    const CacheEntry *entry = findEntry(key);
+    return entry != nullptr && entry->state != CacheState::Empty;
+}
+
+bool RouteClient::formatRoute(const char *callsign, char *out, size_t outLen) {
+    out[0] = '\0';
+    if (outLen == 0) {
+        return false;
+    }
+
+    char key[9];
+    normalizeCallsign(callsign, key, sizeof(key));
+    const CacheEntry *entry = findEntry(key);
+    if (entry == nullptr || entry->state != CacheState::Found) {
+        return false;
+    }
+    if (entry->originLabel[0] == '\0' || entry->destLabel[0] == '\0') {
+        return false;
+    }
+
+    snprintf(out, outLen, "%s -> %s", entry->originLabel, entry->destLabel);
+    return true;
+}
+
+bool RouteClient::fetchIfUncached(const char *callsign) {
+    char key[9];
+    normalizeCallsign(callsign, key, sizeof(key));
+    if (!callsignLikelyRouteable(key)) {
+        return false;
+    }
+    if (findEntry(key) != nullptr) {
+        return false;
+    }
+    if (s_lastFetchMs != 0 && (millis() - s_lastFetchMs) < kMinFetchIntervalMs) {
+        return false;
+    }
+
+    char originLabel[28];
+    char destLabel[28];
+    if (!fetchRouteFromApi(key, originLabel, sizeof(originLabel), destLabel, sizeof(destLabel))) {
+        return false;
+    }
+
+    s_lastFetchMs = millis();
+
+    CacheEntry *entry = allocEntry(key);
+    strncpy(entry->callsign, key, sizeof(entry->callsign) - 1);
+    entry->callsign[sizeof(entry->callsign) - 1] = '\0';
+
+    if (originLabel[0] != '\0' && destLabel[0] != '\0') {
+        strncpy(entry->originLabel, originLabel, sizeof(entry->originLabel) - 1);
+        entry->originLabel[sizeof(entry->originLabel) - 1] = '\0';
+        strncpy(entry->destLabel, destLabel, sizeof(entry->destLabel) - 1);
+        entry->destLabel[sizeof(entry->destLabel) - 1] = '\0';
+        entry->state = CacheState::Found;
+        Serial.printf("route: %s %s -> %s\n", key, originLabel, destLabel);
+    } else {
+        entry->originLabel[0] = '\0';
+        entry->destLabel[0] = '\0';
+        entry->state = CacheState::NotFound;
+        Serial.printf("route: %s not found\n", key);
+    }
+
+    return true;
+}
+
+bool RouteClient::prefetchOne(const char *const *callsigns, size_t count, size_t *cursor) {
+    if (callsigns == nullptr || count == 0 || cursor == nullptr) {
+        return false;
+    }
+
+    const size_t start = *cursor % count;
+    for (size_t attempt = 0; attempt < count; ++attempt) {
+        const size_t idx = (start + attempt) % count;
+        const char *callsign = callsigns[idx];
+        if (callsign == nullptr || callsign[0] == '\0') {
+            continue;
+        }
+        if (isCached(callsign)) {
+            continue;
+        }
+        if (fetchIfUncached(callsign)) {
+            *cursor = (idx + 1) % count;
+            return true;
+        }
+        return false;
+    }
+
+    return false;
+}

--- a/firmware/src/widgets/planeradarwidget/RouteClient.h
+++ b/firmware/src/widgets/planeradarwidget/RouteClient.h
@@ -1,0 +1,15 @@
+#ifndef ROUTE_CLIENT_H
+#define ROUTE_CLIENT_H
+
+#include <cstddef>
+
+class RouteClient {
+public:
+    static void clearCache();
+    static bool isCached(const char *callsign);
+    static bool formatRoute(const char *callsign, char *out, size_t outLen);
+    static bool fetchIfUncached(const char *callsign);
+    static bool prefetchOne(const char *const *callsigns, size_t count, size_t *cursor);
+};
+
+#endif


### PR DESCRIPTION
## Summary
Adds a **Plane Radar** widget that shows live nearby aircraft on the center orb and detail views on the other four orbs. Inspired by [ESP32-Plane-Radar](https://github.com/MatixYo/ESP32-Plane-Radar).
- **Orb 0:** Radar view with range rings, aircraft positions, heading triangles, speed vectors, and beyond-range edge dots
- **Orbs 1–4:** Closest aircraft detail (callsign, type, route, speed, altitude, arriving/departing hint, military/PIA/LADD flags)
- **OK button:** Cycles radar range (5 / 10 / 15 / 25 mi ring presets); selection is saved in NVS
- **Incremental redraws:** Refreshes without full-screen flash; detail orbs stay pinned to the same aircraft between polls
**Data sources (no API keys required):**
- ADS-B: [adsb.fi opendata API](https://opendata.adsb.fi/)
- Routes: [adsbdb.com](https://api.adsbdb.com/)
Disabled by default (`WIDGET_OFF`) so existing builds are unchanged.
---
## Configuration (`config.h`)
Add to your `config.h` (see `config.h.template`):
    #define INCLUDE_PLANE_RADAR WIDGET_ON   // WIDGET_ON | WIDGET_OFF | WIDGET_DISABLED
Optional overrides (defaults in `config.system.h`):
| Define | Default | Description |
|--------|---------|-------------|
| `PLANE_RADAR_LAT` | `48.4284` | Radar center latitude |
| `PLANE_RADAR_LON` | `-123.3656` | Radar center longitude |
| `PLANE_RADAR_RANGE_INDEX` | `1` | Initial range preset: `0`=5 mi, `1`=10 mi, `2`=15 mi, `3`=25 mi (inner ring label) |
| `PLANE_RADAR_FETCH_INTERVAL_SEC` | `3` | ADS-B poll interval (seconds) |
| `PLANE_RADAR_CYCLE_DELAY` | `180` | Seconds to stay on Plane Radar before widget carousel advances |
| `PLANE_RADAR_UNITS_METRIC` | (undefined) | Define to show range label in km; omit for miles |
Example:
    #define INCLUDE_PLANE_RADAR WIDGET_ON
    #define PLANE_RADAR_LAT 45.4215
    #define PLANE_RADAR_LON -75.6972
    #define PLANE_RADAR_RANGE_INDEX 1
    #define PLANE_RADAR_FETCH_INTERVAL_SEC 5
    #define PLANE_RADAR_CYCLE_DELAY 180
    // #define PLANE_RADAR_UNITS_METRIC
Most settings can also be changed in the **web UI** when web-based config is enabled (`planeLat`, `planeLon`, `planeFetchSec`, `planeCycleSec`, `planeUnitsMetric`, enable/disable).
