### PR TITLE
Fix GlobalTime tick drift and blocking NTP/timezone retries

### DIFF
--- a/firmware/src/core/globaltime/GlobalTime.cpp
+++ b/firmware/src/core/globaltime/GlobalTime.cpp
@@ -35,31 +35,69 @@ time_t GlobalTime::getUnixEpochIfAvailable() {
 }
 
 void GlobalTime::updateTime(bool force) {
-    if (force || millis() - m_updateTimer > m_oneSecond) {
-        m_updateTimer = millis();
-        m_timeClient->update();
-        if (m_timeClient->isTimeSet()) {
-            // NTP time is valid
-            if (m_timeZoneOffset == -1 || (m_nextTimeZoneUpdate > 0 && m_unixEpoch > m_nextTimeZoneUpdate)) {
+    // Rollover-safe, drift-free 1s scheduler.
+    // Advancing m_updateTimer by whole periods (instead of setting it to now)
+    // keeps this sampler phase-locked to the 1000ms grid of millis(), so
+    // displayed seconds are never skipped due to accumulated drift (the old
+    // "> 1000 then timer = millis()" version drifted by the loop latency on
+    // every tick and skipped roughly one displayed second per 3 minutes).
+    uint32_t now = millis();
+    uint32_t elapsed = now - (uint32_t) m_updateTimer;
+    if (!force && elapsed < m_oneSecond) {
+        return;
+    }
+    if (elapsed >= m_oneSecond) {
+        m_updateTimer += m_oneSecond * (elapsed / m_oneSecond);
+    }
+    // NTPClient::update() re-attempts a *blocking* forceUpdate() (up to
+    // ~1010ms of delay(10) waiting for the UDP reply) on EVERY call once a
+    // refresh is due, because a failed attempt never advances _lastUpdate.
+    // If the NTP server stops responding, that turns this once-per-second
+    // tick into a ~1s stall of the whole render loop. Gate the attempts
+    // ourselves so a dead server costs at most one stall per retry
+    // interval; timekeeping continues via millis() inside getEpochTime().
+    uint32_t ntpRetryInterval = m_timeClient->isTimeSet() ? m_ntpRetryInterval : m_ntpInitialRetryInterval;
+    if (force || m_lastNtpAttempt == 0 || (uint32_t) (now - m_lastNtpAttempt) >= ntpRetryInterval) {
+        m_lastNtpAttempt = now;
+        if (m_timeClient->update()) {
+            m_lastNtpSync = now;
+        } else if (m_timeClient->isTimeSet() && (uint32_t) (now - m_lastNtpSync) >= m_updateInterval + m_ntpRetryInterval) {
+            // Only a real failure: a refresh is overdue (m_updateInterval
+            // has passed since the last successful sync) and the attempt
+            // did not succeed. update() also returns false when a refresh
+            // simply is not due yet, which must not be logged.
+            Log.warningln("NTP update failed (server not responding), will retry later");
+        }
+    }
+    if (m_timeClient->isTimeSet()) {
+        // NTP time is valid
+        if (m_timeZoneOffset == -1 || (m_nextTimeZoneUpdate > 0 && m_unixEpoch > m_nextTimeZoneUpdate)) {
+            // getTimeZoneOffsetFromAPI() is a blocking HTTP call (multiple
+            // seconds on an unreachable server). Without gating it is
+            // retried on every 1s tick until it succeeds (boot with a dead
+            // API, or DST changeover), stalling the render loop each time.
+            uint32_t tzRetryInterval = (m_timeZoneOffset == -1) ? m_tzInitialRetryInterval : m_tzRetryInterval;
+            if (m_lastTimeZoneAttempt == 0 || (uint32_t) (now - m_lastTimeZoneAttempt) >= tzRetryInterval) {
+                m_lastTimeZoneAttempt = now;
                 getTimeZoneOffsetFromAPI();
             }
-            m_unixEpoch = m_timeClient->getEpochTime();
-            m_minute = minute(m_unixEpoch);
-            if (m_format24hour) {
-                m_hour = hour(m_unixEpoch);
-            } else {
-                m_hour = hourFormat12(m_unixEpoch);
-            }
-            m_hour24 = hour(m_unixEpoch);
-            m_second = second(m_unixEpoch);
-
-            m_day = day(m_unixEpoch);
-            m_month = month(m_unixEpoch);
-            m_monthName = i18n(t_months, m_month - 1);
-            m_year = year(m_unixEpoch);
-            m_weekday = i18n(t_weekdays, weekday(m_unixEpoch) - 1);
-            m_time = String(m_hour) + ":" + (m_minute < 10 ? "0" + String(m_minute) : String(m_minute));
         }
+        m_unixEpoch = m_timeClient->getEpochTime();
+        m_minute = minute(m_unixEpoch);
+        if (m_format24hour) {
+            m_hour = hour(m_unixEpoch);
+        } else {
+            m_hour = hourFormat12(m_unixEpoch);
+        }
+        m_hour24 = hour(m_unixEpoch);
+        m_second = second(m_unixEpoch);
+
+        m_day = day(m_unixEpoch);
+        m_month = month(m_unixEpoch);
+        m_monthName = i18n(t_months, m_month - 1);
+        m_year = year(m_unixEpoch);
+        m_weekday = i18n(t_weekdays, weekday(m_unixEpoch) - 1);
+        m_time = String(m_hour) + ":" + (m_minute < 10 ? "0" + String(m_minute) : String(m_minute));
     }
 }
 

--- a/firmware/src/core/globaltime/GlobalTime.h
+++ b/firmware/src/core/globaltime/GlobalTime.h
@@ -78,6 +78,20 @@ private:
     unsigned long m_oneSecond = 1000;
     unsigned long m_updateTimer = 0;
 
+    // NTP attempt gating (see updateTime()): NTPClient's blocking forceUpdate()
+    // is re-attempted on every update() call once a refresh is due, so failed
+    // attempts must be rate-limited ourselves.
+    unsigned long m_ntpRetryInterval = 61 * 1000; // between attempts after a failed refresh
+    unsigned long m_ntpInitialRetryInterval = 5 * 1000; // until the first successful sync after boot
+    unsigned long m_lastNtpAttempt = 0;
+    unsigned long m_lastNtpSync = 0;
+
+    // Timezone API attempt gating (see updateTime()): the API call is a
+    // blocking HTTP request and must not be retried on every 1s tick.
+    unsigned long m_tzInitialRetryInterval = 30 * 1000; // until the first successful fetch
+    unsigned long m_tzRetryInterval = 5 * 60 * 1000; // after a failed refresh
+    unsigned long m_lastTimeZoneAttempt = 0;
+
     bool m_format24hour{FORMAT_24_HOUR};
     std::string m_ntpServer{NTP_SERVER};
 

--- a/firmware/test/host_sim_long_uptime.py
+++ b/firmware/test/host_sim_long_uptime.py
@@ -1,0 +1,195 @@
+"""Host-side simulation of Info-Orbs clock timing logic.
+
+Replicates the exact uint32 arithmetic used on the ESP32 to prove:
+ 1. The OLD GlobalTime scheduler (m_updateTimer = millis() after a '> 1000'
+    check) accumulates drift and skips displayed seconds -> parity-driven
+    colon stalls (the "long irregular colon" bug).
+ 2. The NEW drift-free scheduler (m_updateTimer += whole periods) never
+    skips a second, including across the 49.7-day millis() rollover.
+ 3. The NEW 500 ms colon blinker toggles at a stable cadence across rollover.
+ 4. The seconds-dot arc angles stay within valid bounds for all inputs,
+    and out-of-range seconds / non-status orbs are rejected.
+
+Run:  python firmware/test/host_sim_long_uptime.py
+"""
+
+U32 = 1 << 32
+
+
+def u32(x):
+    return x & (U32 - 1)
+
+
+def epoch_seconds(ms, ntp_last_update, ntp_epoch):
+    """NTPClient::getEpochTime(): epoch + (millis() - lastUpdate) / 1000."""
+    return ntp_epoch + u32(ms - ntp_last_update) // 1000
+
+
+def simulate_old_scheduler(start_ms, duration_ms, loop_latency_ms):
+    """OLD: if (millis() - t > 1000) { ...; t = millis(); } -> drifts."""
+    ms = start_ms
+    t = start_ms
+    ntp_last, ntp_epoch = start_ms, 1_000_000
+    last_seen = epoch_seconds(ms, ntp_last, ntp_epoch)
+    skips = colon_stalls = 0
+    end = ms + duration_ms
+    while ms < end:
+        ms += loop_latency_ms
+        if u32(ms - t) > 1000:
+            t = ms
+            sec = epoch_seconds(ms, ntp_last, ntp_epoch)
+            delta = sec - last_seen
+            if delta > 1:
+                skips += delta - 1
+                if delta % 2 == 0:
+                    colon_stalls += 1  # parity unchanged -> colon frozen >= 2s
+            last_seen = sec
+    return skips, colon_stalls
+
+
+def simulate_new_scheduler(start_ms, duration_ms, loop_latency_ms):
+    """NEW: elapsed >= 1000 -> t += 1000 * (elapsed // 1000). Drift-free."""
+    ms = start_ms
+    t = start_ms
+    ntp_last, ntp_epoch = start_ms, 1_000_000
+    last_seen = epoch_seconds(ms, ntp_last, ntp_epoch)
+    skips = updates = 0
+    end = ms + duration_ms
+    while ms < end:
+        ms += loop_latency_ms
+        elapsed = u32(u32(ms) - u32(t))
+        if elapsed >= 1000:
+            t = t + 1000 * (elapsed // 1000)  # catch-up, no drift
+            sec = epoch_seconds(ms, ntp_last, ntp_epoch)
+            if sec - last_seen > 1:
+                skips += sec - last_seen - 1
+            last_seen = sec
+            updates += 1
+    return skips, updates
+
+
+def simulate_colon_blink(start_ms, duration_ms, loop_latency_ms):
+    """NEW ClockWidget colon: toggle every 500 ms, rollover-safe."""
+    ms = start_ms
+    prev = start_ms
+    visible = True
+    toggle_times = []
+    end = ms + duration_ms
+    while ms < end:
+        ms += loop_latency_ms
+        elapsed = u32(u32(ms) - u32(prev))
+        if elapsed >= 500:
+            prev = prev + 500 * (elapsed // 500)
+            visible = not visible
+            toggle_times.append(ms)
+    # Cadence check: nominal toggle grid is every 500 ms; observation jitter
+    # is bounded by loop latency.
+    intervals = [b - a for a, b in zip(toggle_times, toggle_times[1:])]
+    return intervals
+
+
+def simulate_colon_with_stalls(duration_ms, stall_every_ms, stall_ms, loop_latency_ms):
+    """NEW parity-correct colon blinker with periodic loop stalls injected
+    (models one blocking NTP attempt per retry interval).
+
+    Returns (phase_errors, toggles): phase_errors counts observations where the
+    colon state disagrees with the ideal 500 ms square wave outside a stall.
+    """
+    ms = 0
+    prev = 0
+    visible = True
+    next_stall = stall_every_ms
+    phase_errors = toggles = 0
+    while ms < duration_ms:
+        if ms >= next_stall:
+            ms += stall_ms  # blocking NTP forceUpdate timeout
+            next_stall += stall_every_ms
+        else:
+            ms += loop_latency_ms
+        elapsed = u32(u32(ms) - u32(prev))
+        if elapsed >= 500:
+            periods = elapsed // 500
+            prev = prev + 500 * periods
+            if periods % 2 == 1:
+                visible = not visible
+            toggles += 1
+            # Ideal square wave: visible == (whole 500ms periods since t0) even
+            ideal = (prev // 500) % 2 == 0
+            if visible != ideal:
+                phase_errors += 1
+    return phase_errors, toggles
+
+
+def check_seconds_dot():
+    """Validate displaySeconds() guards and arc angle bounds."""
+    for orb in range(-2, 7):
+        for sec in range(-5, 66):
+            draws = not (orb != 2 or sec < 0 or sec > 59)
+            if draws:
+                if sec < 30:
+                    start, endang = 6 * sec + 180, 6 * sec + 186
+                else:
+                    start, endang = 6 * sec - 180, 6 * sec - 174
+                assert 0 <= start <= 360 and 0 <= endang <= 360, (sec, start, endang)
+                assert orb == 2
+            else:
+                assert orb != 2 or sec < 0 or sec > 59
+    return True
+
+
+ROLLOVER = U32  # millis() wraps every 4294967296 ms = 49.71 days
+
+print("=== 1. OLD GlobalTime scheduler (3 simulated hours, 5 ms loop) ===")
+skips, stalls = simulate_old_scheduler(0, 3 * 3600 * 1000, 5)
+print(f"    skipped seconds: {skips}, colon parity stalls (>=2s frozen): {stalls}")
+assert skips > 0, "expected the old scheduler to skip seconds"
+
+print("=== 2. NEW GlobalTime scheduler (3 simulated hours, 5 ms loop) ===")
+skips, updates = simulate_new_scheduler(0, 3 * 3600 * 1000, 5)
+print(f"    skipped seconds: {skips} over {updates} updates")
+assert skips == 0
+
+print("=== 3. NEW scheduler across millis() rollover (20 min straddling wrap) ===")
+start = ROLLOVER - 10 * 60 * 1000  # 10 min before the 49.7-day wrap
+skips, updates = simulate_new_scheduler(start, 20 * 60 * 1000, 5)
+print(f"    skipped seconds: {skips} over {updates} updates (start=0x{u32(start):08X})")
+assert skips == 0
+
+print("=== 4. NEW scheduler with blocked loop (2500 ms stalls injected) ===")
+skips, updates = simulate_new_scheduler(0, 3600 * 1000, 2500)
+# seconds jump by 2-3 during a blocked loop, but scheduler must not spiral
+print(f"    updates: {updates} (catch-up works, no spiral)")
+
+print("=== 5. Colon blink cadence across rollover (30 min straddling wrap) ===")
+intervals = simulate_colon_blink(ROLLOVER - 15 * 60 * 1000, 30 * 60 * 1000, 5)
+bad = [i for i in intervals if not 490 <= i <= 510]
+print(f"    toggles: {len(intervals) + 1}, min/max interval: {min(intervals)}/{max(intervals)} ms, out-of-tolerance: {len(bad)}")
+assert not bad, f"unstable colon intervals: {bad[:5]}"
+
+print("=== 6. Colon blink long-run drift (24 simulated hours, 7 ms loop) ===")
+intervals = simulate_colon_blink(0, 24 * 3600 * 1000, 7)
+total = sum(intervals)
+expected = len(intervals) * 500
+drift = total - expected
+print(f"    toggles: {len(intervals) + 1}, cumulative drift vs 500 ms grid: {drift} ms")
+assert abs(drift) <= 7, "cumulative drift detected"
+
+print("=== 7. Seconds-dot bounds / orb ownership (all orbs x seconds -5..65) ===")
+check_seconds_dot()
+print("    all draws bounded to orb 2, seconds 0..59, angles within 0..360")
+
+print("=== 8. Colon blink under NTP failure ===")
+# OLD GlobalTime: dead NTP server blocks EVERY 1s tick ~1010 ms -> the render
+# loop runs ~1x/s and the colon degrades to ~1s on / 1s off (reported bug).
+intervals = simulate_colon_blink(0, 3600 * 1000, 1010)
+print(f"    old (loop stalled every tick): median toggle interval = {sorted(intervals)[len(intervals) // 2]} ms (bug: ~1010, not 500)")
+assert sorted(intervals)[len(intervals) // 2] > 900
+# NEW GlobalTime: attempts gated to one per 61 s -> a single ~1s stall per
+# minute; parity-correct catch-up keeps the colon phase-locked to the 500 ms
+# grid at all other times.
+errors, toggles = simulate_colon_with_stalls(2 * 3600 * 1000, 61_000, 1010, 5)
+print(f"    new (1 gated stall / 61s): {toggles} toggles over 2h, phase errors: {errors}")
+assert errors == 0
+
+print()
+print("ALL CHECKS PASSED")


### PR DESCRIPTION
Split from #330 (part 1 of 3), rebased onto dev as requested.

## Summary
- **Drift-free 1s scheduler**: `updateTime()` used `m_updateTimer = millis()` after a `>` comparison, which accumulates drift and eventually skips seconds (visible as irregular colon blink / tick jumps). The timer now advances by whole 1000ms periods, staying phase-locked to the second grid. All comparisons use rollover-safe unsigned arithmetic (millis() wraps at ~49.7 days).
- **Gated NTP attempts**: NTPClient's `forceUpdate()` blocks ~1010ms on timeout *without* advancing `_lastUpdate`, so once an update is due, a dead/unreachable NTP server stalls every loop iteration by ~1s (the whole UI degrades to ~1Hz). NTP attempts are now rate-limited (61s once synced, 5s until first sync) so a failing server costs at most one blocked call per interval.
- **Gated timezone API attempts**: same class of bug — a failing timezone API call could be retried every second, each one a blocking HTTP request. Now retried at 30s until first success, then 5min after a failure.

## Test plan
- [x] Builds with `pio run -e infoorbs-v0_3`
- [x] Host-side simulation (`firmware/test/host_sim_long_uptime.py`) covering scheduler drift, uint32 rollover, and NTP-failure stall behavior — all checks pass
- [x] Equivalent change soak-tested on hardware for several days on the main-based branch from #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)