### PR TITLE
Fix clock colon blink regularity and AM/PM redraw heap churn

### DIFF
--- a/firmware/src/widgets/clockwidget/ClockWidget.cpp
+++ b/firmware/src/widgets/clockwidget/ClockWidget.cpp
@@ -65,6 +65,10 @@ void ClockWidget::setup() {
     m_lastDisplay2Digit = "";
     m_lastDisplay4Digit = "";
     m_lastDisplay5Digit = "";
+    m_lastAmPm = "";
+    m_lastSecondSingle = -1;
+    m_colonVisible = true;
+    m_colonBlinkPrev = millis();
 }
 
 void ClockWidget::draw(bool force) {
@@ -88,35 +92,73 @@ void ClockWidget::draw(bool force) {
         m_lastDisplay5Digit = m_display5Digit;
     }
 
-    if (m_secondSingle != m_lastSecondSingle || force) {
-        if (m_secondSingle % 2 == 0) {
-            displayDigit(2, "", ":", m_fgColor, false);
-        } else {
-            displayDigit(2, "", ":", m_shadowColor, false);
+    if (m_type == (int) ClockType::NORMAL) {
+        // Colon blink: stable 500ms on / 500ms off, driven directly by
+        // millis() instead of the parity of the displayed second, so a
+        // skipped or repeated second (scheduler drift, NTP resync) can
+        // never stall the blink. Rollover-safe unsigned arithmetic.
+        uint32_t now = millis();
+        uint32_t elapsed = now - (uint32_t) m_colonBlinkPrev;
+        if (elapsed >= m_colonBlinkInterval) {
+            // Advance in whole periods so no cumulative drift builds up,
+            // and catch up in one step if the loop was blocked for a while.
+            // Toggle by period parity so a blocked loop (e.g. a blocking
+            // network call) can never invert the blink phase.
+            uint32_t periods = elapsed / m_colonBlinkInterval;
+            m_colonBlinkPrev += m_colonBlinkInterval * periods;
+            if (periods % 2 == 1) {
+                m_colonVisible = !m_colonVisible;
+            }
+            displayColon();
+        } else if (force) {
+            displayColon();
         }
+    } else if (m_secondSingle != m_lastSecondSingle || force) {
+        // NIXIE/custom clocks: the colon is a full-screen image, so keep the
+        // original 1s cadence (on during even seconds) instead of doubling
+        // the JPG decode load with a 500ms blink.
+        if (m_secondSingle % 2 == 0) {
+            displayDigit(SCREEN_STATUS, "", ":", m_fgColor, false);
+        } else {
+            displayDigit(SCREEN_STATUS, "", ":", m_shadowColor, false);
+        }
+    }
+
+    if (m_secondSingle != m_lastSecondSingle || force) {
         if (m_showSecondTicks) {
             if (!isCustomClock(m_type)) {
                 // not a custom clock -> clear background
-                displaySeconds(2, m_lastSecondSingle, TFT_BLACK);
+                displaySeconds(SCREEN_STATUS, m_lastSecondSingle, TFT_BLACK);
             }
-            displaySeconds(2, m_secondSingle, m_fgColor);
+            displaySeconds(SCREEN_STATUS, m_secondSingle, m_fgColor);
         }
         m_lastSecondSingle = m_secondSingle;
-        if (m_type == (int) ClockType::NORMAL) {
-            if (m_format == CLOCK_FORMAT_12_HOUR_AMPM) {
-                if (m_amPm != m_lastAmPm) {
-                    // Clear old AM/PM
-                    displayAmPm(m_lastAmPm, TFT_BLACK);
-                    m_lastAmPm = m_amPm;
-                }
-                displayAmPm(m_amPm, m_fgColor);
+    }
+
+    if (m_type == (int) ClockType::NORMAL && m_format == CLOCK_FORMAT_12_HOUR_AMPM) {
+        // Only redraw AM/PM when it actually changes (or on a forced redraw).
+        // Redrawing it every second forced a TTF font unload/reload cycle each
+        // time (see displayAmPm), which fragments the heap over long uptimes
+        // and eventually corrupts rendering.
+        if (m_amPm != m_lastAmPm || force) {
+            if (m_lastAmPm.length() > 0 && m_amPm != m_lastAmPm) {
+                // Clear old AM/PM
+                displayAmPm(m_lastAmPm, TFT_BLACK);
             }
+            displayAmPm(m_amPm, m_fgColor);
+            m_lastAmPm = m_amPm;
         }
     }
 }
 
+void ClockWidget::displayColon() {
+    // The colon lives on the middle/status orb only
+    displayDigit(SCREEN_STATUS, "", ":", m_colonVisible ? m_fgColor : m_shadowColor, false);
+}
+
 void ClockWidget::displayAmPm(String &amPm, uint32_t color) {
-    m_manager.selectScreen(2);
+    // The AM/PM indicator is owned by the middle/status orb
+    m_manager.selectScreen(SCREEN_STATUS);
     m_manager.setFontColor(color, TFT_BLACK);
     // Workaround for 12h AM/PM problem
     // The colon is slightly offset and that's a problem because to remove them, we paint over them
@@ -235,6 +277,10 @@ DigitOffset ClockWidget::getOffsetForDigit(const String &digit) {
 }
 
 void ClockWidget::displayDigit(int displayIndex, const String &lastDigit, const String &digit, uint32_t color, bool shadowing) {
+    if (displayIndex < 0 || displayIndex >= NUM_SCREENS) {
+        // Never draw to an invalid orb
+        return;
+    }
     uint32_t start = millis();
     if (m_type == (int) ClockType::NIXIE || isCustomClock(m_type)) {
         if (digit == ":" && color == m_shadowColor) {
@@ -284,6 +330,14 @@ void ClockWidget::displayDigit(int displayIndex, const String &lastDigit, const 
 }
 
 void ClockWidget::displaySeconds(int displayIndex, int seconds, int color) {
+    if (displayIndex != SCREEN_STATUS) {
+        // The seconds tick is owned by the middle/status orb; never draw it elsewhere
+        return;
+    }
+    if (seconds < 0 || seconds > 59) {
+        // Out-of-range (e.g. -1 before the first update): nothing to draw or clear
+        return;
+    }
     if (color != m_fgColor && m_type != (int) ClockType::NORMAL) {
         // ignore clear tick (we draw the whole image anyway)
         return;

--- a/firmware/src/widgets/clockwidget/ClockWidget.cpp
+++ b/firmware/src/widgets/clockwidget/ClockWidget.cpp
@@ -98,29 +98,36 @@ void ClockWidget::draw(bool force) {
         // skipped or repeated second (scheduler drift, NTP resync) can
         // never stall the blink. Rollover-safe unsigned arithmetic.
         uint32_t now = millis();
-        uint32_t elapsed = now - (uint32_t) m_colonBlinkPrev;
-        if (elapsed >= m_colonBlinkInterval) {
-            // Advance in whole periods so no cumulative drift builds up,
-            // and catch up in one step if the loop was blocked for a while.
-            // Toggle by period parity so a blocked loop (e.g. a blocking
-            // network call) can never invert the blink phase.
-            uint32_t periods = elapsed / m_colonBlinkInterval;
-            m_colonBlinkPrev += m_colonBlinkInterval * periods;
-            if (periods % 2 == 1) {
-                m_colonVisible = !m_colonVisible;
+        if (force) {
+            // Forced redraws (widget switch, clock face change) restart the
+            // blink phase with the colon visible, so it never reappears in
+            // the "off" state right after a screen clear.
+            m_colonVisible = true;
+            m_colonBlinkPrev = now;
+            displayColon();
+        } else {
+            uint32_t elapsed = now - (uint32_t) m_colonBlinkPrev;
+            if (elapsed >= m_colonBlinkInterval) {
+                // Advance in whole periods so no cumulative drift builds up,
+                // and catch up in one step if the loop was blocked for a while.
+                // Toggle by period parity so a blocked loop (e.g. a blocking
+                // network call) can never invert the blink phase.
+                uint32_t periods = elapsed / m_colonBlinkInterval;
+                m_colonBlinkPrev += m_colonBlinkInterval * periods;
+                if (periods % 2 == 1) {
+                    m_colonVisible = !m_colonVisible;
+                }
+                displayColon();
             }
-            displayColon();
-        } else if (force) {
-            displayColon();
         }
     } else if (m_secondSingle != m_lastSecondSingle || force) {
         // NIXIE/custom clocks: the colon is a full-screen image, so keep the
         // original 1s cadence (on during even seconds) instead of doubling
         // the JPG decode load with a 500ms blink.
         if (m_secondSingle % 2 == 0) {
-            displayDigit(SCREEN_STATUS, "", ":", m_fgColor, false);
+            displayDigit(SCREEN_MIDDLE, "", ":", m_fgColor, false);
         } else {
-            displayDigit(SCREEN_STATUS, "", ":", m_shadowColor, false);
+            displayDigit(SCREEN_MIDDLE, "", ":", m_shadowColor, false);
         }
     }
 
@@ -128,9 +135,9 @@ void ClockWidget::draw(bool force) {
         if (m_showSecondTicks) {
             if (!isCustomClock(m_type)) {
                 // not a custom clock -> clear background
-                displaySeconds(SCREEN_STATUS, m_lastSecondSingle, TFT_BLACK);
+                displaySeconds(SCREEN_MIDDLE, m_lastSecondSingle, TFT_BLACK);
             }
-            displaySeconds(SCREEN_STATUS, m_secondSingle, m_fgColor);
+            displaySeconds(SCREEN_MIDDLE, m_secondSingle, m_fgColor);
         }
         m_lastSecondSingle = m_secondSingle;
     }
@@ -153,12 +160,12 @@ void ClockWidget::draw(bool force) {
 
 void ClockWidget::displayColon() {
     // The colon lives on the middle/status orb only
-    displayDigit(SCREEN_STATUS, "", ":", m_colonVisible ? m_fgColor : m_shadowColor, false);
+    displayDigit(SCREEN_MIDDLE, "", ":", m_colonVisible ? m_fgColor : m_shadowColor, false);
 }
 
 void ClockWidget::displayAmPm(String &amPm, uint32_t color) {
     // The AM/PM indicator is owned by the middle/status orb
-    m_manager.selectScreen(SCREEN_STATUS);
+    m_manager.selectScreen(SCREEN_MIDDLE);
     m_manager.setFontColor(color, TFT_BLACK);
     // Workaround for 12h AM/PM problem
     // The colon is slightly offset and that's a problem because to remove them, we paint over them
@@ -330,7 +337,7 @@ void ClockWidget::displayDigit(int displayIndex, const String &lastDigit, const 
 }
 
 void ClockWidget::displaySeconds(int displayIndex, int seconds, int color) {
-    if (displayIndex != SCREEN_STATUS) {
+    if (displayIndex != SCREEN_MIDDLE) {
         // The seconds tick is owned by the middle/status orb; never draw it elsewhere
         return;
     }

--- a/firmware/src/widgets/clockwidget/ClockWidget.h
+++ b/firmware/src/widgets/clockwidget/ClockWidget.h
@@ -89,8 +89,13 @@ public:
     String getName() override;
 
 private:
+    // The middle/status orb exclusively owns the colon, the seconds tick
+    // and the AM/PM indicator. Digit orbs (0, 1, 3, 4) must never receive them.
+    static constexpr int SCREEN_STATUS = 2;
+
     void addConfigToManager();
     void changeFormat();
+    void displayColon();
     void displayDigit(int displayIndex, const String &lastDigit, const String &digit, uint32_t color, bool shadowing);
     void displayDigit(int displayIndex, const String &lastDigit, const String &digit, uint32_t color);
     void displaySeconds(int displayIndex, int seconds, int color);
@@ -121,16 +126,27 @@ private:
     time_t m_unixEpoch;
     int m_timeZoneOffset;
 
+// Sample the (cached) global time and redraw at 10Hz. Sampling well below 1s
+// guarantees no displayed second is ever skipped due to sampling aliasing,
+// and allows the colon to blink at a stable 500ms cadence. draw()/update()
+// are cheap no-ops when nothing changed.
 #ifndef CLOCK_UPDATE_DELAY
-    #define CLOCK_UPDATE_DELAY TimeFrequency::OneSecond
+    #define CLOCK_UPDATE_DELAY TimeFrequency::OneHundredMilliseconds
 #endif
 
 #ifndef CLOCK_DRAW_DELAY
-    #define CLOCK_DRAW_DELAY TimeFrequency::OneSecond
+    #define CLOCK_DRAW_DELAY TimeFrequency::OneHundredMilliseconds
 #endif
 
     WidgetTimer &m_drawTimer;
     WidgetTimer &m_updateTimer;
+
+    // Colon blink (NORMAL clock): full 1s cycle (500ms on / 500ms off), driven
+    // directly by millis() and independent of the seconds counter so it can
+    // never stall when a second is skipped or repeated (e.g. NTP resync).
+    unsigned long m_colonBlinkInterval = 500;
+    unsigned long m_colonBlinkPrev = 0;
+    bool m_colonVisible = true;
 
     int m_minuteSingle;
     int m_hourSingle;

--- a/firmware/src/widgets/clockwidget/ClockWidget.h
+++ b/firmware/src/widgets/clockwidget/ClockWidget.h
@@ -89,9 +89,9 @@ public:
     String getName() override;
 
 private:
-    // The middle/status orb exclusively owns the colon, the seconds tick
-    // and the AM/PM indicator. Digit orbs (0, 1, 3, 4) must never receive them.
-    static constexpr int SCREEN_STATUS = 2;
+    // The middle orb exclusively owns the colon, the seconds tick and the
+    // AM/PM indicator. Digit orbs (0, 1, 3, 4) must never receive them.
+    static constexpr int SCREEN_MIDDLE = 2;
 
     void addConfigToManager();
     void changeFormat();


### PR DESCRIPTION
Split from #330 (part 2 of 3), rebased onto dev as requested.

## Summary
- **Smooth, drift-free colon blink (NORMAL clock)**: the colon was driven by seconds parity from GlobalTime, so any skipped/duplicated second made the blink irregular. It's now driven by a millis()-based 500ms blinker with parity-correct catch-up (if draw is delayed by multiple periods, visibility only toggles on an odd number of elapsed periods). NIXIE/custom clocks keep the image-based 1s colon.
- **AM/PM redrawn only on change**: `displayAmPm()` was called every second, and each call reloads TTF fonts (DSEG7↔DSEG14) plus per-loop String allocations — over days of uptime this fragments the heap and eventually corrupts glyph rendering (stray "PM" artifacts observed after long uptime). It's now redrawn only when the value changes or on force, with the old value cleared first.
- **Bounds/ownership guards**: `displayDigit()` validates the display index; `displaySeconds()` only draws on the status orb and validates the seconds range — defense against a corrupted index painting tick marks on the wrong panel.
- `CLOCK_UPDATE_DELAY`/`CLOCK_DRAW_DELAY` defaults changed from `OneSecond` to `OneHundredMilliseconds` so the 500ms colon blinker actually gets a chance to run; all per-second work is still internally gated on second changes, so this doesn't add redraw load.

## Test plan
- [x] Builds with `pio run -e infoorbs-v0_3`
- [x] Equivalent change soak-tested on hardware for several days on the main-based branch from #330 (colon blinks evenly, no AM/PM artifacts)
- [x] Verify NIXIE/custom clock colon still alternates each second

🤖 Generated with [Claude Code](https://claude.com/claude-code)