### PR TITLE
Fix screen CS crosstalk window and add IRAM_ATTR to button ISRs

### DIFF
--- a/firmware/src/core/button/Button.cpp
+++ b/firmware/src/core/button/Button.cpp
@@ -13,7 +13,8 @@ void Button::begin(uint8_t pin) {
     pinMode(m_pin, BUTTON_MODE);
 }
 
-void Button::isrButtonChange() {
+// IRAM_ATTR: called from a GPIO interrupt; must not execute from flash cache
+void IRAM_ATTR Button::isrButtonChange() {
     if (millis() - m_lastPinLevelChange < DEBOUNCE_TIME) {
         return;
     }

--- a/firmware/src/core/screenmanager/ScreenManager.cpp
+++ b/firmware/src/core/screenmanager/ScreenManager.cpp
@@ -96,12 +96,22 @@ OpenFontRender &ScreenManager::getRender() {
 
 // Selects a single screen
 void ScreenManager::selectScreen(int screen) {
+    // Deselect all screens first: writing the CS pins in a single pass can
+    // briefly leave both the old and the new screen selected at the same
+    // time, so SPI data may leak to the wrong panel during the transition.
     for (int i = 0; i < NUM_SCREENS; i++) {
-        int orbRotation = ConfigManager::getInstance()->getConfigInt("orbRotation", ORB_ROTATION);
-        bool rotateDisplays = orbRotation == 1 || orbRotation == 2;
-        int currentDisplay = rotateDisplays ? NUM_SCREENS - i - 1 : i;
-        digitalWrite(m_screen_cs[currentDisplay], i == screen ? LOW : HIGH);
+        digitalWrite(m_screen_cs[i], HIGH);
     }
+    if (screen < 0 || screen >= NUM_SCREENS) {
+        // Invalid index: leave all screens deselected instead of selecting
+        // an out-of-bounds CS pin / wrong panel
+        Log.warningln("selectScreen: invalid screen index %d", screen);
+        return;
+    }
+    int orbRotation = ConfigManager::getInstance()->getConfigInt("orbRotation", ORB_ROTATION);
+    bool rotateDisplays = orbRotation == 1 || orbRotation == 2;
+    int targetDisplay = rotateDisplays ? NUM_SCREENS - screen - 1 : screen;
+    digitalWrite(m_screen_cs[targetDisplay], LOW);
 }
 
 // Fills all screens with a color

--- a/firmware/src/core/utils/MainHelper.cpp
+++ b/firmware/src/core/utils/MainHelper.cpp
@@ -38,11 +38,13 @@ void MainHelper::init(WiFiManager *wm, ConfigManager *cm, ScreenManager *sm, Wid
 }
 
 /**
- * The ISR handlers must be static
+ * The ISR handlers must be static and must live in IRAM: without IRAM_ATTR a
+ * button edge during a flash write (e.g. saving config to NVS/LittleFS)
+ * crashes the ESP32 with "Cache disabled but cached memory region accessed".
  */
-void MainHelper::isrButtonChangeLeft() { buttonLeft.isrButtonChange(); }
-void MainHelper::isrButtonChangeMiddle() { buttonMiddle.isrButtonChange(); }
-void MainHelper::isrButtonChangeRight() { buttonRight.isrButtonChange(); }
+void IRAM_ATTR MainHelper::isrButtonChangeLeft() { buttonLeft.isrButtonChange(); }
+void IRAM_ATTR MainHelper::isrButtonChangeMiddle() { buttonMiddle.isrButtonChange(); }
+void IRAM_ATTR MainHelper::isrButtonChangeRight() { buttonRight.isrButtonChange(); }
 
 void MainHelper::setupButtons() {
     bool invertButtons = s_orbRotation == 1 || s_orbRotation == 2;


### PR DESCRIPTION
Split from #330 (part 3 of 3), rebased onto dev as requested.

## Summary
- **selectScreen: deselect-all-first**: the previous single-pass loop wrote CS pins in order, which can transiently leave both the old and new panel selected, letting SPI data leak to the wrong orb during the transition (observed on hardware as stray pixels appearing on a different orb). Now all CS lines are raised first, then only the target is lowered. Also adds a bounds check on the screen index (logs a warning and leaves everything deselected instead of driving a wrong/out-of-range CS pin), and hoists the ConfigManager read out of the loop.
- **IRAM_ATTR on button ISRs**: `Button::isrButtonChange()` and the MainHelper ISR wrappers run from GPIO interrupts but weren't placed in IRAM. If the interrupt fires while flash cache is disabled (NVS/LittleFS write), the ESP32 crashes with a `Cache disabled but cached memory region accessed` exception. `millis()` and `digitalRead()` are IRAM-safe, so marking the handlers is sufficient.

## Test plan
- [x] Builds with `pio run -e infoorbs-v0_3`
- [x] Press buttons during a config save (flash write) — no crash
- [x] Verify widgets still render to the correct orbs with orbRotation 0-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)